### PR TITLE
Update ALLOWED_IPS defaults

### DIFF
--- a/services/llm_docs-mcp/README.md
+++ b/services/llm_docs-mcp/README.md
@@ -1,0 +1,14 @@
+
+# `llm_docs-mcp`
+
+Servicio que expone una API basada en FastAPI para consultar documentos.
+
+## Variables de Entorno
+
+- **`ALLOWED_IPS`**: lista separada por comas de IPs o rangos CIDR
+  autorizados para acceder a la pasarela. El valor por defecto incluye la
+  red de Docker:
+
+  ```
+  127.0.0.1,172.18.0.0/16,192.168.1.100
+  ```

--- a/services/llm_docs-mcp/config.env.example
+++ b/services/llm_docs-mcp/config.env.example
@@ -1,4 +1,5 @@
-ALLOWED_IPS=127.0.0.1,192.168.1.100,172.18.0.0/16
+# IPs o rangos CIDR permitidos (incluye la red de Docker)
+ALLOWED_IPS=127.0.0.1,172.18.0.0/16,192.168.1.100
 API_USERNAME=admin
 API_PASSWORD=supersecret
 LOG_PATH=/app/gateway.log

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -32,7 +32,10 @@ app.add_middleware(
 )
 # Seguridad básica HTTP/IP
 security = HTTPBasic()
-ALLOWED_IPS = os.getenv("ALLOWED_IPS", "127.0.0.1,172.1.8.0.0/16,192.168.1.100").split(",")
+ALLOWED_IPS = os.getenv(
+    "ALLOWED_IPS",
+    "127.0.0.1,172.18.0.0/16,192.168.1.100"
+).split(",")
 API_USERNAME = os.getenv("API_USERNAME", "admin")
 API_PASSWORD = os.getenv("API_PASSWORD", "admin")
 class IPWhitelistMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
## Summary
- broaden allowed IP range for llm_docs service
- document ALLOWED_IPS variable in README and env example

## Testing
- `pip install -r services/llm_docs-mcp/requirements.txt`
- `pip install -r services/scheduler-mcp/requirements.txt`
- `pip install httpx`
- `PYTHONPATH=services/scheduler-mcp:services/llm_docs-mcp pytest -q services/llm_docs-mcp/test_tools.py services/scheduler-mcp/test/test_scheduler.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6843149012a0832fa2b9c031cae2ce03