### PR TITLE
Update MCP_URL in env example

### DIFF
--- a/gateways/web-interface/.env.example
+++ b/gateways/web-interface/.env.example
@@ -2,7 +2,7 @@
 # Buenas prácticas Publilab Consulting: centraliza endpoints y credenciales aquí
 
 # URL del MCP (Microservicio Central de Procesos)
-MCP_URL=http://mcp-core:5000/route
+MCP_URL=http://mcp-core:5000/orchestrate
 
 # Puerto del servidor WebSocket (opcional)
 PORT=3000


### PR DESCRIPTION
## Summary
- update the MCP URL for web-interface `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684319e9ce94832f9d38f2d49daf3ed7