### PR TITLE
Fix default allowed IP network

### DIFF
--- a/services/llm_docs-mcp/config.env.example
+++ b/services/llm_docs-mcp/config.env.example
@@ -1,3 +1,4 @@
+# Lista de IPs o subredes permitidas (separadas por comas)
 ALLOWED_IPS=127.0.0.1,192.168.1.100,172.18.0.0/16
 API_USERNAME=admin
 API_PASSWORD=supersecret

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -32,7 +32,8 @@ app.add_middleware(
 )
 # Seguridad básica HTTP/IP
 security = HTTPBasic()
-ALLOWED_IPS = os.getenv("ALLOWED_IPS", "127.0.0.1,172.1.8.0.0/16,192.168.1.100").split(",")
+# Redes o direcciones IP permitidas por defecto
+ALLOWED_IPS = os.getenv("ALLOWED_IPS", "127.0.0.1,172.18.0.0/16,192.168.1.100").split(",")
 API_USERNAME = os.getenv("API_USERNAME", "admin")
 API_PASSWORD = os.getenv("API_PASSWORD", "admin")
 class IPWhitelistMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
## Summary
- update `ALLOWED_IPS` default to `172.18.0.0/16`
- add comment for ALLOWED_IPS in example env file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684321790748832fa9d93356c7ab18b4