### PR TITLE
Fix env example MCP URL

### DIFF
--- a/gateways/evolution-api/.env.example
+++ b/gateways/evolution-api/.env.example
@@ -2,7 +2,7 @@
 # Buenas prácticas Publilab Consulting: centraliza endpoints y credenciales aquí
 
 # URL del MCP (Microservicio Central de Procesos)
-MCP_URL=http://mcp-core:5000/route
+MCP_URL=http://mcp-core:5000/orchestrate
 
 # Puerto del servidor Express/WebSocket (opcional)
 PORT=8080


### PR DESCRIPTION
## Summary
- update the evolution-api `.env.example` to point to the correct orchestrate URL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6843305f33ac832f91bf119add261dde