### PR TITLE
Fix complaint success response

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -151,7 +151,7 @@ def call_tool_microservice(tool: str, params: Dict[str, Any]) -> Dict[str, Any]:
         "params": params
     }
     resp = requests.post(service_url, json=payload, timeout=30)
-    if resp.status_code == 200:
+    if 200 <= resp.status_code < 300:
         return resp.json()
     else:
         return {"error": f"Error {resp.status_code}: {resp.text}"}


### PR DESCRIPTION
## Summary
- treat 2xx status codes as success when calling tool microservice

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: llama_cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68542ba35ad0832faeb2f86601cd9a7f