### PR TITLE
Fix model volume path for mcp-core

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,11 +95,11 @@ services:
       - REDIS_HOST=redis
     ports:
       - "5000:5000"
-    networks:
+  networks:
       - munbot-net
-    volumes:
-    - ./services/mcp-core/models:/mcp-core/models
-    depends_on:
+  volumes:
+    - ./mcp-core/models:/mcp-core/models
+  depends_on:
       redis:
         condition: service_healthy
       postgres:


### PR DESCRIPTION
## Summary
- correct volume path in `docker-compose.yml` so mcp-core can find the model

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for llama_cpp and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685773cf2060832fa71e67f9f43bf266