### PR TITLE
Enhance FAQ matching with confirmation

### DIFF
--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -148,3 +148,29 @@ class ConversationalContextManager:
             json.dumps(context),
             ex=self.session_expiry_seconds
         )
+
+    def set_faq_clarification(self, session_id: str, data: Dict[str, Any]):
+        """Guarda datos de una aclaración de FAQ pendiente."""
+        context = self.get_context(session_id)
+        context["faq_pending"] = data
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds
+        )
+
+    def get_faq_clarification(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Obtiene la aclaración de FAQ pendiente si existe."""
+        context = self.get_context(session_id)
+        return context.get("faq_pending")
+
+    def clear_faq_clarification(self, session_id: str):
+        """Elimina cualquier aclaración de FAQ pendiente."""
+        context = self.get_context(session_id)
+        if "faq_pending" in context:
+            del context["faq_pending"]
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds
+        )


### PR DESCRIPTION
## Summary
- add FAQ clarification helpers to context manager
- support higher fuzzy matching threshold with clarifications and keyword fallback
- prompt users to confirm or choose FAQ suggestions during orchestration

## Testing
- `pip install -q fastapi uvicorn psycopg2-binary requests pydantic gunicorn redis numpy llama-cpp-python==0.3.9 rapidfuzz`
- `pip install -q httpx scikit-learn`
- `pytest -q` *(fails: Model path does not exist; missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6858aedfdb78832f8627ae4b0dbe1519