### PR TITLE
Improve FAQ formatting and channel handling

### DIFF
--- a/gateways/web-interface/socketServer.js
+++ b/gateways/web-interface/socketServer.js
@@ -42,7 +42,8 @@ io.on('connection', (socket) => {
             const payload = {
                 pregunta: msg,
                 context: { sender: socket.id },
-                session_id: socket.sessionId // USAR sessionId del socket
+                session_id: socket.sessionId, // USAR sessionId del socket
+                channel: 'web'
             };
             // Enviar el mensaje al MCP
             const response = await axios.post(MCP_URL, payload);

--- a/mcp-core/databases/faq_respuestas.json
+++ b/mcp-core/databases/faq_respuestas.json
@@ -129,5 +129,10 @@
     "pregunta": ["¿Cómo puedo agendar una cita?", "¿Cómo puedo pedir una hora?", "¿Cómo puedo pedir una cita?"],
     "respuesta": "Para agendar una cita puedes hacer la solicitud en este mismo mensaje y te ayudaré a generarla. ¿Quieres agendar una cita ahora?",
     "categoria": "citas"
+  },
+  {
+    "pregunta": ["¿Cómo obtengo mi clave única?", "¿Cuál es el proceso para obtener la clave única?", "¿Cómo sacar la clave única?"],
+    "respuesta": "1. Ingresa a https://claveunica.gob.cl\n2. Selecciona \"Obtener Clave Única\"\n3. Sigue las instrucciones y valida tu identidad en línea o en una oficina.",
+    "categoria": "tramites"
   }
-] 
+]


### PR DESCRIPTION
## Summary
- map field labels for document responses via `CAMPO_LABELS`
- add `adapt_markdown_for_channel` helper and channel support in API
- include numbered instructions FAQ for Clave Única
- send channel info from web socket gateway

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6858b9838e88832f866e89272485b496