### PR TITLE
Fix JSON BOM decoding issue

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1190,7 +1190,12 @@ OFICINAS_PATH = os.path.join(os.path.dirname(__file__), "databases/oficina_info.
 FAQS_PATH = os.path.join(os.path.dirname(__file__), "databases/faq_respuestas.json")
 
 def cargar_json(path):
-    with open(path, "r", encoding="utf-8") as f:
+    # Use ``utf-8-sig`` to seamlessly handle JSON files that may include a
+    # UTF-8 BOM (Byte Order Mark). ``json.load`` does not skip the BOM by
+    # default which results in ``JSONDecodeError`` when such a file is read
+    # with ``utf-8``. The ``utf-8-sig`` codec transparently strips the BOM if
+    # present while remaining compatible with regular UTF-8 files.
+    with open(path, "r", encoding="utf-8-sig") as f:
         return json.load(f)
 
 documentos = cargar_json(DOCUMENTOS_PATH)


### PR DESCRIPTION
## Summary
- handle optional BOM when reading JSON files in the orchestrator

## Testing
- `pytest -q` *(fails: Model path does not exist: models/Llama-3.2-3B-Instruct-Q6_K.gguf)*

------
https://chatgpt.com/codex/tasks/task_e_68597307788c832f82cce164e0f968b9