### PR TITLE
Add persistent logging for unanswered questions and feedback

### DIFF
--- a/docs/USER_FEEDBACK.md
+++ b/docs/USER_FEEDBACK.md
@@ -1,0 +1,21 @@
+# Registro de Preguntas sin Respuesta y Feedback
+
+Este documento describe brevemente las tablas incorporadas para almacenar preguntas no contestadas y el feedback de los usuarios.
+
+## preguntas_no_contestadas
+- **id**: identificador autoincremental.
+- **texto_pregunta**: pregunta original enviada por el usuario.
+- **fecha_hora**: marca temporal de registro.
+- **usuario_id**: identificador del usuario si se dispone.
+- **intent_detectada**: intención detectada por el orquestador (por defecto `unknown`).
+- **respuesta_dada**: mensaje que envió el bot.
+- **canal**: canal de origen (opcional).
+
+## feedback_usuario
+- **id**: clave primaria.
+- **pregunta_id**: referencia opcional a `preguntas_no_contestadas`.
+- **feedback_texto**: texto que envió el usuario al valorar la respuesta.
+- **fecha_hora**: momento de registro.
+- **usuario_id**: identificador opcional del usuario.
+
+Estas tablas permiten analizar con mayor detalle en qué temas falla el bot y recopilar comentarios directos de los usuarios para mejorar continuamente el sistema.

--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -227,3 +227,30 @@ class ConversationalContextManager:
             json.dumps(context),
             ex=self.session_expiry_seconds
         )
+
+    # ---- Manejo de feedback de usuario ----
+    def set_feedback_pending(self, session_id: str, pregunta_id: Optional[int]):
+        """Marca una pregunta como pendiente de recibir feedback."""
+        context = self.get_context(session_id)
+        context["feedback_question"] = pregunta_id
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds
+        )
+
+    def get_feedback_pending(self, session_id: str) -> Optional[int]:
+        """Obtiene el ID de la pregunta pendiente de feedback."""
+        context = self.get_context(session_id)
+        return context.get("feedback_question")
+
+    def clear_feedback_pending(self, session_id: str):
+        """Limpia el indicador de feedback pendiente."""
+        context = self.get_context(session_id)
+        if "feedback_question" in context:
+            del context["feedback_question"]
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds
+        )

--- a/mcp-core/databases/init-postgres.sql
+++ b/mcp-core/databases/init-postgres.sql
@@ -178,4 +178,24 @@ INSERT INTO documento_notas (documento_id, nota) VALUES
   ((SELECT id FROM documentos WHERE id_documento='DOC002'), 'El certificado es requerido para trámites de postulación a beneficios.'),
   ((SELECT id FROM documentos WHERE id_documento='DOC003'), 'La ayuda social está sujeta a evaluación y disponibilidad de recursos.');
 
+-- Tabla para registrar preguntas no contestadas por el bot
+CREATE TABLE IF NOT EXISTS preguntas_no_contestadas (
+    id SERIAL PRIMARY KEY,
+    texto_pregunta TEXT NOT NULL,
+    fecha_hora TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    usuario_id VARCHAR(255),
+    intent_detectada TEXT DEFAULT 'unknown',
+    respuesta_dada TEXT,
+    canal TEXT
+);
+
+-- Feedback explícito entregado por el usuario sobre la respuesta
+CREATE TABLE IF NOT EXISTS feedback_usuario (
+    id SERIAL PRIMARY KEY,
+    pregunta_id INTEGER REFERENCES preguntas_no_contestadas(id) ON DELETE CASCADE,
+    feedback_texto TEXT,
+    fecha_hora TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    usuario_id VARCHAR(255)
+);
+
 COMMIT;


### PR DESCRIPTION
## Summary
- track unanswered questions and feedback in postgres
- expose methods in `context_manager` for pending feedback
- store a record when fallbacks occur and ask for feedback
- request feedback after successful FAQ or complaint answers
- document new tables

## Testing
- `python -m py_compile mcp-core/orchestrator.py mcp-core/context_manager.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6859849e8c4c832faab163d083632655