### PR TITLE
Implement session expiry notice and cancel command

### DIFF
--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -31,6 +31,9 @@ class ConversationalContextManager:
             "content": bot_response,
             "timestamp": datetime.now().isoformat()
         })
+
+        # Registrar última actividad
+        context["last_activity"] = datetime.now().isoformat()
         
         # Mantener solo los últimos 10 mensajes
         context["history"] = context["history"][-10:]
@@ -90,6 +93,11 @@ class ConversationalContextManager:
         """Obtiene el historial de la conversación."""
         context = self.get_context(session_id)
         return context.get("history", [])
+
+    def get_last_activity(self, session_id: str) -> Optional[str]:
+        """Devuelve la marca de tiempo de la última actividad."""
+        context = self.get_context(session_id)
+        return context.get("last_activity")
 
     def get_history_as_string(self, history: List[Dict[str, str]]) -> str:
         """Convierte el historial en una cadena de texto."""

--- a/tests/test_orchestrator_cancel.py
+++ b/tests/test_orchestrator_cancel.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+import os
+import types
+import fakeredis
+from fastapi.testclient import TestClient
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+client = TestClient(orchestrator.app)
+
+
+def test_cancel_reclamo_flow():
+    r = client.post('/orchestrate', json={'pregunta': 'quiero registrar un reclamo'})
+    assert r.status_code == 200
+    data = r.json()
+    sid = data['session_id']
+    assert '¿Cómo te llamas' in data['respuesta']
+
+    r = client.post('/orchestrate', json={'pregunta': 'Juan Perez', 'session_id': sid})
+    assert r.status_code == 200
+    assert 'RUT' in r.json()['respuesta']
+
+    r = client.post('/orchestrate', json={'pregunta': 'cancelar', 'session_id': sid})
+    assert r.status_code == 200
+    resp = r.json()['respuesta'].lower()
+    assert 'cancelado' in resp
+    assert orchestrator.context_manager.get_pending_field(sid) is None
+    assert orchestrator.context_manager.get_complaint_state(sid) is None


### PR DESCRIPTION
## Summary
- track last activity in context manager
- detect expired sessions and notify user
- allow users to cancel active flows with keywords
- improve complaint error messages
- add regression test for cancel behaviour

## Testing
- `pytest tests/test_orchestrator_cancel.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685992c0f010832fbfd3291b2b711afd