### PR TITLE
Show document notes in responses

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1721,6 +1721,7 @@ KEYWORD_FIELDS = {
     "utilidad": ["utilidad", "para que sirve", "beneficio"],
     "penalidad": ["penalidad", "sancion", "sanción", "que pasa si no", "multas"],
     "costo": ["costo", "precio", "valor", "coste"],
+    "Notas": ["nota", "notas"],
 }
 
 # Alias conocidos para referirse a algunos documentos con nombres alternativos.
@@ -1740,6 +1741,7 @@ CAMPO_LABELS = {
     "utilidad": "¿Para qué sirve?",
     "penalidad": "Penalidad",
     "tiempo_validez": "Vigencia",
+    "Notas": "Nota",
 }
 
 
@@ -1788,6 +1790,8 @@ def armar_respuesta_combinada(doc, campos):
 
         if campo == "Requisitos":
             respuesta = f"Para obtener **{doc_name}**, necesitas:\n{lista}"
+            if doc.get("Notas"):
+                respuesta += f"\n**Nota:** {doc['Notas']}"
         elif campo == "Dónde_Obtener":
             respuesta = f"Puedes obtener **{doc_name}** en {lista}."
         elif campo == "Horario_Atencion":
@@ -1876,6 +1880,8 @@ def armar_respuesta_combinada(doc, campos):
     ):
         nota_val = doc.get("Notas") or doc.get("nota")
         respuesta.append(f"Nota: {nota_val}")
+    elif doc.get("Notas") and ("Requisitos" in campos or len(campos) > 1):
+        respuesta.append(f"Nota: {doc['Notas']}")
 
     respuesta_final = "\n\n".join(respuesta)
     return respuesta_final + "\n\n¿Quieres saber algo más sobre este trámite?"
@@ -2057,6 +2063,10 @@ def responder_sobre_documento(
                 )
 
             respuesta = armar_respuesta_combinada(doc, campos_existentes)
+            if doc.get("Notas") and "Nota:" not in respuesta and (
+                "Requisitos" in campos_existentes or len(campos_existentes) > 1
+            ):
+                respuesta += f"\n\n**Nota:** {doc['Notas']}"
             if missing:
                 respuesta += (
                     "\n"

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -1,5 +1,22 @@
+import os
+import sys
+import types
 import unittest
 from fastapi.testclient import TestClient
+
+os.environ["ALLOWED_IPS"] = "testclient,127.0.0.1"
+
+# Stub llama_cpp to avoid heavy dependency in tests
+fake_llama = types.ModuleType("llama_cpp")
+class FakeLlama:
+    def __init__(self, *a, **k):
+        pass
+    def __call__(self, *a, **k):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules["llama_cpp"] = fake_llama
+
 from gateway import app
 
 class TestGateway(unittest.TestCase):

--- a/services/scheduler-mcp/test/test_scheduler.py
+++ b/services/scheduler-mcp/test/test_scheduler.py
@@ -1,4 +1,7 @@
+import os
 import pytest
+os.environ["POSTGRES_PORT"] = "5432"
+os.environ["TESTING"] = "1"
 from fastapi.testclient import TestClient
 from app import app
 

--- a/tests/test_document_responses.py
+++ b/tests/test_document_responses.py
@@ -4,6 +4,8 @@ import os
 import types
 import fakeredis
 
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+
 # Mock llama_cpp before importing orchestrator
 fake_llama = types.ModuleType('llama_cpp')
 class FakeLlama:
@@ -71,3 +73,15 @@ def test_keyword_fuzzy():
     resp = orchestrator.responder_sobre_documento('cual es el coste del Permiso de Aterrizaje')
     assert 'permiso de aterrizaje' in resp.lower()
     assert 'costo' in resp.lower() or 'precio' in resp.lower()
+
+
+def test_requisitos_include_nota():
+    resp = orchestrator.responder_sobre_documento('requisitos del Certificado de Residencia Definitiva')
+    assert 'certificado de residencia definitiva' in resp.lower()
+    assert 'nota' in resp.lower()
+
+
+def test_general_query_includes_nota():
+    resp = orchestrator.responder_sobre_documento('Como obtener el Certificado de Residencia Definitiva')
+    assert 'certificado de residencia definitiva' in resp.lower()
+    assert 'nota' in resp.lower()

--- a/tests/test_orchestrator_cancel.py
+++ b/tests/test_orchestrator_cancel.py
@@ -5,6 +5,8 @@ import types
 import fakeredis
 from fastapi.testclient import TestClient
 
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+
 # Mock llama_cpp before importing orchestrator
 fake_llama = types.ModuleType('llama_cpp')
 class FakeLlama:


### PR DESCRIPTION
## Summary
- include `Notas` in recognized keyword fields and labels
- append note when listing requirements or general document info
- add environment hacks for tests and stub heavy dependencies
- test that notes are included in responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac69ed52c832f894dba7d2e689d0a