### PR TITLE
Handle farewell messages

### DIFF
--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -210,6 +210,17 @@ class ConversationalContextManager:
             ex=self.session_expiry_seconds
         )
 
+    def clear_suggestion_state(self, session_id: str):
+        """Limpia cualquier estado relacionado con sugerencias pendientes."""
+        context = self.get_context(session_id)
+        for key in ("faq_pending", "doc_clarify", "doc_options"):
+            context.pop(key, None)
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds,
+        )
+
     def set_selected_document(self, session_id: str, name: str):
         """Guarda el documento seleccionado por el usuario."""
         context = self.get_context(session_id)

--- a/tests/test_farewell.py
+++ b/tests/test_farewell.py
@@ -1,0 +1,46 @@
+import importlib.util
+import sys
+import os
+import types
+import fakeredis
+from fastapi.testclient import TestClient
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["FAQ_DB_PATH"] = os.path.join('mcp-core', 'databases', 'faq_respuestas.json')
+os.environ["PROMPTS_PATH"] = os.path.join('mcp-core', 'prompts')
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("FAQ_DB_PATH", None)
+os.environ.pop("PROMPTS_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+client = TestClient(orchestrator.app)
+
+
+def test_farewell_resets_context():
+    r1 = client.post('/orchestrate', json={'pregunta': 'hola'})
+    assert r1.status_code == 200
+    sid = r1.json()['session_id']
+
+    r2 = client.post('/orchestrate', json={'pregunta': 'Adios, gracias por tu ayuda', 'session_id': sid})
+    assert r2.status_code == 200
+    assert 'hasta luego' in r2.json()['respuesta'].lower()
+    assert orchestrator.context_manager.get_context(sid) == {}

--- a/tests/test_suggestion_exit.py
+++ b/tests/test_suggestion_exit.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+import os
+import types
+import fakeredis
+from fastapi.testclient import TestClient
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["FAQ_DB_PATH"] = os.path.join('mcp-core', 'databases', 'faq_respuestas.json')
+os.environ["PROMPTS_PATH"] = os.path.join('mcp-core', 'prompts')
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("FAQ_DB_PATH", None)
+os.environ.pop("PROMPTS_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+client = TestClient(orchestrator.app)
+
+
+def test_exit_option_in_faq_choices():
+    r = client.post('/orchestrate', json={'pregunta': 'como puedo obtener una'})
+    assert r.status_code == 200
+    text = r.json()['respuesta'].lower()
+    assert 'mi opción no está en la lista' in text
+    sid = r.json()['session_id']
+
+    r2 = client.post('/orchestrate', json={'pregunta': '4', 'session_id': sid})
+    assert r2.status_code == 200
+    resp = r2.json()['respuesta'].lower()
+    assert 'cuéntame con tus propias palabras' in resp
+    assert orchestrator.context_manager.get_faq_clarification(sid) is None


### PR DESCRIPTION
## Summary
- detect farewell expressions using FAQ data
- clear session when user says goodbye
- add regression test for farewell detection
- add escape option when suggesting FAQ or document selections

## Testing
- `pytest tests/test_farewell.py tests/test_orchestrator_cancel.py tests/test_document_responses.py tests/test_suggestion_exit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5989a424832f871cf6a76977a2d6