### PR TITLE
Implement document menu selection helpers

### DIFF
--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -214,6 +214,59 @@ class ConversationalContextManager:
             ex=self.session_expiry_seconds
         )
 
+    # ---- Manejo de listas de documentos pendientes ----
+    def set_pending_doc_list(self, session_id: str, opciones: List[str]):
+        """Guarda una lista de documentos pendiente de selección."""
+        context = self.get_context(session_id)
+        context["pending_doc_list"] = opciones
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds,
+        )
+
+    def get_pending_doc_list(self, session_id: str) -> Optional[List[str]]:
+        """Obtiene la lista de documentos pendiente de selección."""
+        context = self.get_context(session_id)
+        return context.get("pending_doc_list")
+
+    def clear_pending_doc_list(self, session_id: str):
+        """Elimina la lista de documentos pendiente."""
+        context = self.get_context(session_id)
+        if "pending_doc_list" in context:
+            del context["pending_doc_list"]
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds,
+        )
+
+    def set_pending_doc_type(self, session_id: str, tipo: str):
+        """Guarda el tipo de documento asociado a la lista pendiente."""
+        context = self.get_context(session_id)
+        context["pending_doc_type"] = tipo
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds,
+        )
+
+    def get_pending_doc_type(self, session_id: str) -> Optional[str]:
+        """Obtiene el tipo de documento para la lista pendiente."""
+        context = self.get_context(session_id)
+        return context.get("pending_doc_type")
+
+    def clear_pending_doc_type(self, session_id: str):
+        """Elimina el tipo de documento pendiente."""
+        context = self.get_context(session_id)
+        if "pending_doc_type" in context:
+            del context["pending_doc_type"]
+        self.redis_client.set(
+            f"session:{session_id}",
+            json.dumps(context),
+            ex=self.session_expiry_seconds,
+        )
+
     # ---- Manejo de consultas de trámites pendientes ----
     def set_consultas_tramites_pending(self, session_id: str, value: bool = True):
         context = self.get_context(session_id)

--- a/tests/test_tramites_menu.py
+++ b/tests/test_tramites_menu.py
@@ -43,3 +43,10 @@ def test_tramites_menu_flow():
     assert 'certificado de residencia definitiva' in resp
     assert orchestrator.context_manager.get_context_field(sid, 'pending_doc_list')
     assert orchestrator.context_manager.get_context_field(sid, 'consultas_tramites_pending') is None
+
+    r3 = orchestrator.orchestrate('1', session_id=sid)
+    resp3 = r3['respuesta'].lower()
+    assert 'qué te interesa saber del certificado de residencia definitiva' in resp3
+    assert orchestrator.context_manager.get_context_field(sid, 'pending_doc_list') is None
+    assert orchestrator.context_manager.get_context_field(sid, 'pending_doc_type') is None
+    assert orchestrator.context_manager.get_context_field(sid, 'doc_actual') == 'Certificado de Residencia Definitiva'


### PR DESCRIPTION
## Summary
- add helper methods for pending document list/type
- use new context methods when showing document menu
- support selecting a document from the pending list in orchestrate
- test selecting a document from the menu

## Testing
- `pytest tests/test_tramites_menu.py::test_tramites_menu_flow -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2a4867ec832fa986200a9f19ce20