### PR TITLE
Add document alias mapping and extend field synonyms

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1942,6 +1942,14 @@ documentos = cargar_json(DOCUMENTOS_PATH)
 oficinas = cargar_json(OFICINAS_PATH)
 faqs = cargar_json(FAQS_PATH)
 
+# Construir mapa de alias de documentos combinando los alias declarados en
+# el JSON con los alias definidos manualmente.
+DOC_ALIAS_MAP = {}
+for doc in documentos:
+    for alias in doc.get("alias", []):
+        DOC_ALIAS_MAP[normalize_text(alias)] = doc["Nombre_Documento"]
+
+
 # Controla si se incluyen todos los campos del documento cuando
 # el usuario no especifica un dato particular.
 INCLUIR_FICHA_COMPLETA_POR_DEFECTO = False
@@ -1949,10 +1957,87 @@ INCLUIR_FICHA_COMPLETA_POR_DEFECTO = False
 # Mapeo de palabras clave a campos del JSON de documentos. Las palabras se
 # normalizan sin tildes para realizar la comparación.
 KEYWORD_FIELDS = {
-    "Requisitos": ["Que requisitos necesito", "cuales son los requisitos", "que necesito para obtenerlo", "qué necesito para sacarlo", "que tengo que traer", "que papeles tengo que traer", "que papel tengo que traer", "que papeles tengo que llevar", "que papel tengo que llevar", "que documentos necesito", "que documentos tengo que llevar", "que documentos tengo que traer", "que documentos tengo que presentar", "que documentos tengo que mostrar", "que documentos tengo que entregar", "que documentos tengo que llevar para obtenerlo", "que documentos tengo que llevar para sacarlo", "que documentos tengo que llevar para solicitarlo", "que documentos tengo que llevar para pedirlo", "que papeles necesito", "que papeles tengo que llevar", "que papeles tengo que traer", "que papeles tengo que presentar", "que papeles tengo que mostrar", "que papeles tengo que entregar", "que papeles tengo que llevar para obtenerlo", "que papeles tengo que llevar para sacarlo", "que papeles tengo que llevar para solicitarlo", "que papeles tengo que llevar para pedirlo"],
-    "Dónde_Obtener": ["donde puedo obtenerlo", "donde puedo sacarlo", "donde lo saco", "donde lo consigo", "donde lo obtengo", "donde puedo conseguirlo", "donde puedo sacarlo", "donde puedo pedirlo", "donde puedo solicitarlo", "donde lo solicito", "donde lo pido"],
-    "Horario_Atencion": ["cual es el horario de atencion", "horario de atencion", "A que hora atienden", "A que hora puedo ir", "A que hora abren"],
-    "Correo_Electronico": ["a que correo", "a que mail", "email" "mail", "dame el mail", "dame el correo", "dame el correo electronico", "correo electrónico", "correo", "me puedes dar el correo", "me puedes dar el mail", "me puedes dar el email"],
+    "Requisitos": [
+        "Que requisitos necesito",
+        "cuales son los requisitos",
+        "que necesito para obtenerlo",
+        "qué necesito para sacarlo",
+        "que tengo que traer",
+        "que papeles tengo que traer",
+        "que papel tengo que traer",
+        "que papeles tengo que llevar",
+        "que papel tengo que llevar",
+        "que documentos necesito",
+        "que documentos tengo que llevar",
+        "que documentos tengo que traer",
+        "que documentos tengo que presentar",
+        "que documentos tengo que mostrar",
+        "que documentos tengo que entregar",
+        "que documentos tengo que llevar para obtenerlo",
+        "que documentos tengo que llevar para sacarlo",
+        "que documentos tengo que llevar para solicitarlo",
+        "que documentos tengo que llevar para pedirlo",
+        "que papeles necesito",
+        "que papeles tengo que llevar",
+        "que papeles tengo que traer",
+        "que papeles tengo que presentar",
+        "que papeles tengo que mostrar",
+        "que papeles tengo que entregar",
+        "que papeles tengo que llevar para obtenerlo",
+        "que papeles tengo que llevar para sacarlo",
+        "que papeles tengo que llevar para solicitarlo",
+        "que papeles tengo que llevar para pedirlo",
+    ],
+    "Dónde_Obtener": [
+        "donde puedo obtenerlo",
+        "donde puedo sacarlo",
+        "donde lo saco",
+        "donde lo consigo",
+        "donde lo obtengo",
+        "donde puedo conseguirlo",
+        "donde puedo sacarlo",
+        "donde puedo pedirlo",
+        "donde puedo solicitarlo",
+        "donde lo solicito",
+        "donde lo pido",
+        "donde puedo tramitarlo",
+        "donde tramitarlo",
+        "donde tramitar",
+        "donde se tramita",
+        "en que lugar se tramita",
+    ],
+    "Horario_Atencion": [
+        "cual es el horario de atencion",
+        "horario de atencion",
+        "horario",
+        "horarios",
+        "A que hora atienden",
+        "A que hora puedo ir",
+        "A que hora abren",
+        "cuando atienden",
+        "en que horario",
+        "que horarios tienen",
+        "a que hora cierran",
+    ],
+    "Correo_Electronico": [
+        "correo",
+        "mail",
+        "email",
+        "a que correo",
+        "a que mail",
+        "cual es el correo",
+        "cual es el mail",
+        "cual es el email",
+        "dame el mail",
+        "dame el correo",
+        "dame el correo electronico",
+        "correo electronico",
+        "correo de contacto",
+        "mail de contacto",
+        "me puedes dar el correo",
+        "me puedes dar el mail",
+        "me puedes dar el email",
+    ],
     "telefono": ["cual es el telefono", "cual es el numero", "cual es el número de telefono", "dame el telefono", "dame el numero de telefono", "a que telefono puedo llamar", "a que numero puedo llamar", "telefono", "número de teléfono", "número de telefono", "me puedes dar el telefono", "me puedes dar el número de telefono", "me puedes dar el número de teléfono", "dar el telefono", "dar el número de teléfono", "dar el número de telefono"],
     "Direccion": ["Cual es la direccion", "dirección", "Cual es la ubicacion", "ubicación", "A que direccion", "donde queda", "donde esta", "donde está", "donde se encuentra", "donde queda la oficina", "donde esta la oficina", "donde está la oficina", "donde se encuentra la oficina", "direccion", "dirección de la oficina", "ubicación de la oficina", "donde queda las oficinas", "donde esta las oficinas", "donde está las oficinas", "donde se encuentra las oficinas", "direccion", "dirección de las oficinas", "ubicación de las oficinas", "donde queda el departamento", "donde esta el departamento", "donde está el departamento", "donde se encuentra el departamento", "direccion", "dirección de el departamento", "ubicación de el departamento"],
     "tiempo_validez": ["Cual es su vigencia", "cuando es el tiempo de vigencia", "Cual es la vigencia", "vigencia", "validez", "Cuanto es el tiempo de validez", "duracion", "Cuanto dura","valido", "válido", "Cuanto tiempo es valido"],
@@ -1966,6 +2051,9 @@ DOC_ALIASES = {
     normalize_text("licencia de conducir"): "Licencia Oficial Piloto Federado",
     normalize_text("permiso de circulacion"): "Permiso de Aterrizaje",
 }
+
+# Mezclar alias precargados con los derivados del JSON
+DOC_ALIAS_MAP.update(DOC_ALIASES)
 
 CAMPO_LABELS = {
     "Nombre_Documento": "Nombre del documento",
@@ -2232,7 +2320,7 @@ def responder_sobre_documento(
 
     # Revisar alias conocidos
     if not nombre:
-        for alias_norm, real in DOC_ALIASES.items():
+        for alias_norm, real in DOC_ALIAS_MAP.items():
             if alias_norm in pregunta_norm:
                 nombre = real
                 break


### PR DESCRIPTION
## Summary
- map document aliases from JSON at load time
- expand keyword phrases for document fields
- recognize aliases when resolving user questions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c50cc8980832f895a4360f12e0ff7