### PR TITLE
Improve keyword match filtering

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -252,7 +252,10 @@ def lookup_faq_respuesta(pregunta: str) -> Optional[Dict[str, Any]]:
                 entry_preguntas = [entry_preguntas]
             for alt in entry_preguntas:
                 entry_tokens = set(tokenize(alt))
-                if pregunta_tokens & entry_tokens:
+                common = pregunta_tokens & entry_tokens
+                union = pregunta_tokens | entry_tokens
+                jaccard = len(common) / len(union) if union else 0
+                if len(common) >= 2 or jaccard >= 0.3:
                     keyword_hits.append({"entry": entry, "pregunta": alt})
                     break
         if keyword_hits:

--- a/tests/test_keyword_filter.py
+++ b/tests/test_keyword_filter.py
@@ -1,0 +1,34 @@
+import importlib.util
+import sys
+import os
+import types
+import fakeredis
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["FAQ_DB_PATH"] = os.path.join('mcp-core', 'databases', 'faq_respuestas.json')
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("FAQ_DB_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+
+def test_keyword_overlap_requirement():
+    assert orchestrator.lookup_faq_respuesta('Que requisitos necesito para sacar una cedula') is None


### PR DESCRIPTION
## Summary
- refine keyword matching logic with minimum overlap or Jaccard similarity
- add regression test ensuring queries with few overlapping tokens don't match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ca826a328832f99b523d34a492609