### PR TITLE
Restrict llm_docs service to internal network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,8 +134,8 @@ services:
       - ./services/llm_docs-mcp/.env
     environment:
       - REDIS_HOST=redis
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     restart: unless-stopped
     networks:
       - munbot-net

--- a/docs/NETWORK_FIREWALL.md
+++ b/docs/NETWORK_FIREWALL.md
@@ -1,0 +1,9 @@
+# Firewall y Puertos Internos
+
+Este documento describe las reglas de red aplicadas para los servicios del MCP.
+
+## Servicio `llm_docs-mcp`
+
+Para reducir la exposición externa del servicio de documentos, el contenedor ya no publica el puerto `8000` al host. En lugar de ello, solo se expone internamente dentro de la red `munbot-net` mediante `expose: "8000"` en `docker-compose.yml`.
+
+Se recomienda actualizar el firewall del host para bloquear cualquier conexión externa al puerto 8000. Los servicios que necesiten comunicarse con `llm_docs-mcp` deben hacerlo a través de la red interna de Docker.


### PR DESCRIPTION
## Summary
- reduce llm_docs-mcp exposure by replacing port mapping with internal `expose`
- document firewall rules for the service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d79de81d8832f8f3a9f79e825dc81