### PR TITLE
Normalize intro phrases

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -138,9 +138,10 @@ INTRO_PHRASES = [
 
 def strip_intro_phrase(text: str) -> str:
     """Elimina frases introductorias comunes al inicio de la pregunta."""
-    lowered = text.lower().strip()
+    normalized = normalize_text(text).strip()
     for phrase in INTRO_PHRASES:
-        if lowered.startswith(phrase):
+        phrase_norm = normalize_text(phrase)
+        if normalized.startswith(phrase_norm):
             return text[len(phrase) :].lstrip(",. ")
     return text
 

--- a/tests/test_intro_phrases.py
+++ b/tests/test_intro_phrases.py
@@ -36,3 +36,8 @@ def test_intro_phrase_disponibilidad():
     resp = orchestrator.orchestrate('Quiero saber cual es tu horario de atención')
     assert '24 horas' in resp['respuesta']
 
+
+def test_intro_phrase_accented():
+    resp = orchestrator.orchestrate('Me gustaría saber cual es tu horario de atención')
+    assert '24 horas' in resp['respuesta']
+


### PR DESCRIPTION
## Summary
- normalize intro phrases before matching so diacritics don't break detection
- test accent variants in intro phrases

## Testing
- `pytest tests/test_intro_phrases.py -q`
- `pytest -q` *(fails: test_keyword_overlap_requirement, test_permiso_aterrizaje, test_exit_option_in_faq_choices, test_tokenize_removes_common_words)*

------
https://chatgpt.com/codex/tasks/task_e_68654f2e3b44832fa7c2141eb2bbf903