### PR TITLE
Clean stopwords

### DIFF
--- a/mcp-core/README.md
+++ b/mcp-core/README.md
@@ -4,6 +4,8 @@ This directory contains the core logic for the Modular Conversational Platform (
 
 ## Structure
 - `orchestrator.py`: Main LLM-based orchestrator for intent recognition and tool invocation.
+- It also defines a minimal `STOPWORDS` list used for tokenization. Duplicates and
+  rarely helpful adverbs were removed to avoid filtering meaningful tokens.
 - `tool_schemas/`: JSON schemas describing each microservice's API as callable tools.
 - `prompts/`: Prompt templates for the LLM to guide tool usage and conversation flow.
 

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -500,6 +500,8 @@ def normalize(text):
 
 
 # Lista de stopwords simples para tokenización básica
+# Stopwords include articles, pronouns and other very common words. Keep this
+# list short to avoid removing meaningful tokens when tokenizing.
 STOPWORDS = {
     "a",
     "al",
@@ -535,13 +537,11 @@ STOPWORDS = {
     "contigo",
     "vos",
     "usted",
-    "el",
     "lo",
     "le",
     "se",
     "si",
     "ella",
-    "la",
     "ello",
     "nosotros",
     "nosotras",
@@ -552,8 +552,6 @@ STOPWORDS = {
     "ustedes",
     "ellos",
     "ellas",
-    "los",
-    "las",
     "les",
     "mio",
     "mia",
@@ -590,36 +588,6 @@ STOPWORDS = {
     "aquello",
     "aquellos",
     "aquellas",
-    "regular",
-    "asi",
-    "alto",
-    "bajo",
-    "rapido",
-    "lento",
-    "deprisa",
-    "despacio",
-    "especialmente",
-    "rapidamente",
-    "facilmente",
-    "frecuentemente",
-    "claramente",
-    "directamente",
-    "silenciosamente",
-    "suavemente",
-    "puntualmente",
-    "responsablemente",
-    "voluntariamente",
-    "formalmente",
-    "minuciosamente",
-    "elocuentemente",
-    "elegantemente",
-    "brillantemente",
-    "cuidadosamente",
-    "alegremente",
-    "generosamente",
-    "intelectualmente",
-    "sigilosamente",
-    "prudentemente",
 }
 
 


### PR DESCRIPTION
## Summary
- deduplicate the `STOPWORDS` list
- remove overly generic adverbs from stopwords
- document stopwords cleanup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656293053c832fb6f136f42f31c995