### PR TITLE
Implement unified preprocessing and scheduler flow

### DIFF
--- a/mcp-core/utils/text.py
+++ b/mcp-core/utils/text.py
@@ -1,0 +1,8 @@
+import unicodedata
+
+def normalize_text(text: str) -> str:
+    """Lowercase, remove accents and keep only alphanumerics and spaces."""
+    text = text.lower().strip()
+    text = "".join(c for c in unicodedata.normalize("NFD", text) if unicodedata.category(c) != "Mn")
+    text = "".join(c for c in text if c.isalnum() or c.isspace())
+    return text


### PR DESCRIPTION
## Summary
- unify text normalization in new `preprocess_input`
- add utilities module with `normalize_text`
- intercept appointment intent before FAQ lookup
- add unified confirmation handler for complaints and appointments
- clean up session id handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865661a3dec832f9e517d1ef08b816b