### PR TITLE
Implement unified sid usage and tuned FAQ

### DIFF
--- a/mcp-core/utils/text.py
+++ b/mcp-core/utils/text.py
@@ -1,0 +1,8 @@
+import unicodedata
+
+def normalize_text(text: str) -> str:
+    """Lowercase, remove accents and keep only alphanumerics and spaces."""
+    text = text.lower().strip()
+    text = "".join(c for c in unicodedata.normalize("NFD", text) if unicodedata.category(c) != "Mn")
+    text = "".join(c for c in text if c.isalnum() or c.isspace())
+    return text


### PR DESCRIPTION
## Summary
- refine STOPWORDS list and use normalized tokenization
- tighten FAQ keyword matching thresholds
- use `sid` consistently across orchestrator session handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi, fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_6865661a3dec832f9e517d1ef08b816b