### PR TITLE
Handle feedback presence in orchestrator

### DIFF
--- a/mcp-core/context_manager.py
+++ b/mcp-core/context_manager.py
@@ -371,6 +371,11 @@ class ConversationalContextManager:
         context = self.get_context(session_id)
         return context.get("feedback_question")
 
+    def has_feedback_pending(self, session_id: str) -> bool:
+        """Indica si hay feedback pendiente para la sesión."""
+        context = self.get_context(session_id)
+        return "feedback_question" in context
+
     def clear_feedback_pending(self, session_id: str):
         """Limpia el indicador de feedback pendiente."""
         context = self.get_context(session_id)

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1464,8 +1464,9 @@ def orchestrate(
             return {"respuesta": respuesta_despedida, "session_id": sid}
 
     # --- Manejar feedback pendiente ---
-    pending_feedback = context_manager.get_feedback_pending(sid)
-    if pending_feedback is not None:
+    has_fb = context_manager.has_feedback_pending(sid)
+    pending_feedback = context_manager.get_feedback_pending(sid) if has_fb else None
+    if has_fb:
         registrar_feedback_usuario(pending_feedback, user_input)
         context_manager.clear_feedback_pending(sid)
         if re.fullmatch(r"(?i)(sí|si|yes|ok|okay|vale)", user_input.strip()):

--- a/tests/test_feedback_pending.py
+++ b/tests/test_feedback_pending.py
@@ -1,0 +1,43 @@
+import importlib.util
+import sys
+import os
+import types
+import fakeredis
+from fastapi.testclient import TestClient
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["FAQ_DB_PATH"] = os.path.join('mcp-core', 'databases', 'faq_respuestas.json')
+os.environ["PROMPTS_PATH"] = os.path.join('mcp-core', 'prompts')
+
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("FAQ_DB_PATH", None)
+os.environ.pop("PROMPTS_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+client = TestClient(orchestrator.app)
+
+
+def test_feedback_acknowledgement():
+    sid = 'feed1'
+    orchestrator.context_manager.set_feedback_pending(sid, None)
+    r = client.post('/orchestrate', json={'pregunta': 'Sí', 'session_id': sid})
+    assert r.status_code == 200
+    resp = r.json()['respuesta']
+    assert 'me alegra que te haya ayudado' in resp.lower()
+    assert not orchestrator.context_manager.has_feedback_pending(sid)


### PR DESCRIPTION
## Summary
- add `has_feedback_pending` to manage feedback flag
- use new method in orchestrator
- test acknowledgement when answering feedback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686812899f88832f96790704a2ca5820