### PR TITLE
Improve text classification

### DIFF
--- a/mcp-core/classification_utils.py
+++ b/mcp-core/classification_utils.py
@@ -11,13 +11,16 @@ def classify_reclamo_response(text: str) -> str:
     Usa una heurística rápida y cae en LLM si es necesario.
     """
     low = text.lower()
-    # 1) Heurística rápida para 'sí'
-    if re.search(r"\b(s[ií]|claro|por supuesto)\b", low):
-        return "affirmative"
-    # 2) Heurística rápida para 'no'
-    if re.search(r"\b(no|nunca|todav[ií]a no)\b", low):
+    # 1) Pregunta si contiene signo de interrogación o palabras interrogativas
+    if "?" in text or re.search(r"^(?:¿\s*)?(c[oó]mo|qu[eé]|qui[eé]n|d[oó]nde|cu[aá]ndo|por\s+qué)\b", low):
+        return "question"
+    # 2) Negativo explícito
+    if re.search(r"\b(no|nunca|todav[ií]a\s+no|a[uú]n\s+no)\b", low):
         return "negative"
-    # 3) Fallback usando LLM
+    # 3) Afirmativo explícito
+    if re.search(r"\b(sí|claro|por supuesto)\b", low):
+        return "affirmative"
+    # 4) Fallback usando LLM
     try:
         prompt = (
             "Clasifica esta respuesta a “¿Te gustaría registrar el reclamo…?” "

--- a/tests/test_classification_utils.py
+++ b/tests/test_classification_utils.py
@@ -1,0 +1,39 @@
+import importlib.util
+import sys
+import os
+import types
+
+# Disable migrations that may require DB
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+
+# Mock llama_cpp before importing classification_utils
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+
+spec = importlib.util.spec_from_file_location('classification_utils', os.path.join('mcp-core','classification_utils.py'))
+classification_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(classification_utils)
+
+
+def test_classify_question():
+    lab = classification_utils.classify_reclamo_response('Quiero saber si el reclamo es an\xf3nimo')
+    assert lab == 'question'
+
+
+def test_classify_affirmative():
+    lab = classification_utils.classify_reclamo_response('S\xed, quiero hacerlo')
+    assert lab == 'affirmative'
+
+
+def test_classify_negative():
+    lab = classification_utils.classify_reclamo_response('No, gracias')
+    assert lab == 'negative'


### PR DESCRIPTION
## Summary
- refine heuristics in `classify_reclamo_response`
- add unit tests for classification logic

## Testing
- `pytest tests/test_classification_utils.py -q`
- ❌ `pytest -q` *(fails: ModuleNotFoundError for fastapi/fakeredis)*

------
https://chatgpt.com/codex/tasks/task_e_686add664190832f86975a8a172adbac