### PR TITLE
Improve complaint confirmation flow

### DIFF
--- a/mcp-core/classification_utils.py
+++ b/mcp-core/classification_utils.py
@@ -12,30 +12,43 @@ def classify_reclamo_response(text: str) -> str:
     """
     low = text.lower()
     # 1) Pregunta si contiene signo de interrogación o palabras interrogativas
-    if "?" in text or re.search(r"^(?:¿\s*)?(c[oó]mo|qu[eé]|qui[eé]n|d[oó]nde|cu[aá]ndo|por\s+qué)\b", low):
+    if "?" in text or re.search(
+        r"^(?:¿\s*)?(qu[ié]n|qu[eé]|c[oó]mo|d[oó]nde|cu[aá]ndo|por\s+qué|para\s+qué)\b",
+        low,
+    ):
+        logging.debug("classify_reclamo_response: question by interrogative")
         return "question"
+
+    # 1.b) palabras 'preguntar/consultar/duda' antes de si/que
+    if re.search(r"(preguntar|consultar|duda).*\b(s[ií]|que|qué)\b", low):
+        logging.debug("classify_reclamo_response: question by 'preguntar/consultar'")
+        return "question"
+
     # 2) Negativo explícito
     if re.search(r"\b(no|nunca|todav[ií]a\s+no|a[uú]n\s+no)\b", low):
+        logging.debug("classify_reclamo_response: negative")
         return "negative"
-    # 3) Afirmativo explícito
-    if re.search(r"\b(sí|claro|por supuesto)\b", low):
+
+    # 3) Afirmativo explícito al inicio
+    if re.search(r"^\s*(sí|claro|por supuesto)\b", low):
+        logging.debug("classify_reclamo_response: affirmative")
         return "affirmative"
+
     # 4) Fallback usando LLM
     try:
         prompt = (
-            "Clasifica esta respuesta a “¿Te gustaría registrar el reclamo…?” "
-            "en una de estas etiquetas: affirmative, negative o question.\n"
-            f"Respuesta: \"{text}\"\nEtiqueta:"
+            "Clasifica la siguiente frase como affirmative, negative o question.\n"
+            f"Frase: '{text}'\nEtiqueta:"
         )
-        lab = llm.generate(
-            prompt,
-            temperature=0,
-            max_tokens=4,
-            timeout=3
-        ).strip().lower()
-        if lab.startswith("affirm"): return "affirmative"
-        if lab.startswith("negat"):  return "negative"
+        lab = llm.generate(prompt, temperature=0, max_tokens=4, timeout=3).strip().lower()
+        if lab.startswith("affirm"):
+            logging.debug("classify_reclamo_response: affirmative via LLM")
+            return "affirmative"
+        if lab.startswith("negat"):
+            logging.debug("classify_reclamo_response: negative via LLM")
+            return "negative"
     except Exception as e:
         logging.error(f"Error clasificando reclamo: {e}")
-    # Por defecto
+
+    logging.debug("classify_reclamo_response: default question")
     return "question"


### PR DESCRIPTION
## Summary
- add refined heuristics for complaint answer classification
- handle complaint questions before intent detection and add logging
- stop detecting new intents while complaint confirmation is pending
- clear flow on negative reply and merge privacy prompts into single message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686af8419d68832f8bd99cbbf8bb53a5