### PR TITLE
Add datetime utilities with natural language parsing

### DIFF
--- a/mcp-core/utils/datetime_utils.py
+++ b/mcp-core/utils/datetime_utils.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+import re
+from dateparser.search import search_dates
+
+
+def parse_nl_datetime(text: str, base_dt: datetime) -> tuple[datetime | None, str | None]:
+    settings = {
+        "RELATIVE_BASE": base_dt,
+        "PREFER_DATES_FROM": "future",
+        "RETURN_AS_TIMEZONE_AWARE": True,
+    }
+    results = search_dates(text, languages=["es"], settings=settings)
+    if not results:
+        return None, None
+
+    match_text, dt = results[0]
+    if dt.hour == base_dt.hour and dt.minute == base_dt.minute and dt.second == base_dt.second:
+        m = re.search(r"a las (\d{1,2})(?::(\d{2}))?", text)
+        if m:
+            hour = int(m.group(1)) % 24
+            minute = int(m.group(2) or 0)
+            dt = dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    return dt, match_text

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -1,0 +1,27 @@
+import importlib.util
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+spec = importlib.util.spec_from_file_location('datetime_utils', os.path.join('mcp-core', 'utils', 'datetime_utils.py'))
+datetime_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(datetime_utils)
+
+
+def test_manana_a_las_diez():
+    base = datetime(2025, 7, 7, 15, 55)
+    dt, _ = datetime_utils.parse_nl_datetime('mañana a las 10', base)
+    assert dt == datetime(2025, 7, 8, 10, 0, tzinfo=dt.tzinfo)
+
+
+def test_proximo_jueves():
+    base = datetime(2025, 7, 7)
+    dt, _ = datetime_utils.parse_nl_datetime('próximo jueves', base)
+    assert dt == datetime(2025, 7, 10, 0, 0, tzinfo=dt.tzinfo)
+
+
+def test_fecha_dia_mes():
+    base = datetime(2025, 7, 7)
+    dt, _ = datetime_utils.parse_nl_datetime('24/08', base)
+    assert dt == datetime(2025, 8, 24, 0, 0, tzinfo=dt.tzinfo)


### PR DESCRIPTION
## Summary
- add `parse_nl_datetime` in `mcp-core/utils/datetime_utils.py`
- new tests for natural language datetime parsing

## Testing
- `pytest tests/test_datetime_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c320ca748832f8de142c45c6cf6e0