### PR TITLE
Add RUT validation and range filter

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -1,13 +1,17 @@
 import os
+import re
+from datetime import date, datetime
+from typing import Optional
+
 import psycopg2
 from psycopg2.extras import RealDictCursor
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Request, Query
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from pydantic import BaseModel, EmailStr
-from datetime import date, datetime
+from pydantic import BaseModel, EmailStr, field_validator
 from notifications import send_email, send_whatsapp
+from rut_utils import validar_y_formatear_rut
 
 # =====================
 # Configuración de entorno y DB
@@ -98,8 +102,24 @@ class AppointmentCreate(BaseModel):
     usu_name: str
     usu_mail: EmailStr
     usu_whatsapp: str
+    rut: Optional[str] = None
     fecha: date
     hora: str
+
+    @field_validator("rut")
+    def _validar_rut(cls, v):
+        if v is None:
+            return v
+        nuevo = validar_y_formatear_rut(v)
+        if not nuevo:
+            raise ValueError("RUT invalido")
+        return nuevo
+
+    @field_validator("usu_whatsapp")
+    def _validar_whatsapp(cls, v):
+        if not re.match(r"^\+[1-9]\d{1,14}$", v):
+            raise ValueError("WhatsApp invalido")
+        return v
 
 class AppointmentOut(AppointmentCreate):
     id: str
@@ -134,16 +154,23 @@ def root():
     }
 
 @app.get("/appointments/available")
-def list_available(fecha: date = None):
-    """Listar slots disponibles para una fecha"""
+def list_available(
+    from_date: date = Query(None, alias="from"),
+    to_date: date = Query(None, alias="to"),
+):
+    """Listar slots disponibles opcionalmente en un rango de fechas."""
     conn = get_db()
     cur = conn.cursor(cursor_factory=RealDictCursor)
     query = "SELECT * FROM appointments WHERE avlb=1 AND usu_conf=0"
-    if fecha:
-        query += " AND fecha = %s"
-        cur.execute(query, (fecha,))
-    else:
-        cur.execute(query)
+    params = []
+    if from_date and to_date:
+        query += " AND fecha BETWEEN %s AND %s"
+        params.extend([from_date, to_date])
+    elif from_date:
+        query += " AND fecha >= %s"
+        params.append(from_date)
+    query += " ORDER BY fecha, hora"
+    cur.execute(query, tuple(params))
     citas = cur.fetchall()
     conn.close()
     return {"disponibles": citas}

--- a/services/scheduler-mcp/rut_utils.py
+++ b/services/scheduler-mcp/rut_utils.py
@@ -1,0 +1,29 @@
+import re
+
+def validar_y_formatear_rut(rut: str) -> str:
+    """Valida y formatea un RUT chileno."""
+    if not rut:
+        return None
+    rut = rut.replace('.', '').replace('-', '').upper().strip()
+    if len(rut) < 8:
+        return None
+    numero = rut[:-1]
+    dv = rut[-1]
+    if not numero.isdigit():
+        return None
+    suma = 0
+    multiplicador = 2
+    for r in reversed(numero):
+        suma += int(r) * multiplicador
+        multiplicador = multiplicador + 1 if multiplicador < 7 else 2
+    dvr = 11 - (suma % 11)
+    if dvr == 11:
+        dvr = '0'
+    elif dvr == 10:
+        dvr = 'K'
+    else:
+        dvr = str(dvr)
+    if dv != dvr:
+        return None
+    rut_formateado = f"{int(numero):,}".replace(',', '.') + '-' + dv
+    return rut_formateado

--- a/tests/test_available_endpoint.py
+++ b/tests/test_available_endpoint.py
@@ -1,0 +1,56 @@
+import importlib.util
+import os
+import sys
+from datetime import date, timedelta
+from fastapi.testclient import TestClient
+
+os.environ["POSTGRES_PORT"] = "5432"
+os.environ["TESTING"] = "1"
+
+base_dir = os.path.join("services", "scheduler-mcp")
+sys.path.insert(0, base_dir)
+spec = importlib.util.spec_from_file_location(
+    "scheduler_app",
+    os.path.join(base_dir, "app.py"),
+)
+scheduler_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(scheduler_app)
+app = scheduler_app.app
+
+client = TestClient(app)
+
+
+def make_dummy(rows):
+    class Dummy:
+        def cursor(self, *a, **k):
+            class C:
+                def execute(self, *a, **k):
+                    pass
+                def fetchall(self_inner):
+                    return rows
+                def fetchone(self_inner):
+                    return None
+            return C()
+        def close(self):
+            pass
+    return Dummy()
+
+
+def test_available_next_week(monkeypatch):
+    rows = [{"id": str(i)} for i in range(10)]
+    monkeypatch.setattr(scheduler_app, "get_db", lambda: make_dummy(rows))
+    start = (date.today() + timedelta(days=7)).isoformat()
+    end = (date.today() + timedelta(days=13)).isoformat()
+    resp = client.get(f"/appointments/available?from={start}&to={end}")
+    assert resp.status_code == 200
+    cantidad = len(resp.json()["disponibles"])
+    assert 7 <= cantidad <= 35
+
+
+def test_available_empty_range(monkeypatch):
+    monkeypatch.setattr(scheduler_app, "get_db", lambda: make_dummy([]))
+    resp = client.get("/appointments/available")
+    assert resp.status_code == 200
+    assert resp.json()["disponibles"] == []
+
+


### PR DESCRIPTION
## Summary
- validate phone and RUT when creating appointments
- support optional from/to range when listing appointments
- sort appointment results
- add test coverage for /appointments/available

## Testing
- `pytest -q tests/test_available_endpoint.py`

------
https://chatgpt.com/codex/tasks/task_e_686c465ac930832f98634f81c2522a77