### PR TITLE
Implement email template support for scheduler

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -215,7 +215,14 @@ def confirm_appointment(body: AppointmentConfirm):
     conn.commit()
     conn.close()
     # Notificación al usuario y funcionario
-    send_email(cita["usu_mail"], "Cita confirmada", f"Su cita con {cita['func']} ha sido confirmada para el {cita['fecha']} a las {cita['hora']}.")
+    send_email(
+        cita["usu_mail"],
+        "Cita confirmada",
+        "email/confirm.html",
+        usuario=cita["usu_name"],
+        fecha_legible=str(cita["fecha"]),
+        hora=cita["hora"],
+    )
     send_whatsapp(cita["usu_whatsapp"], f"Su cita con {cita['func']} ha sido confirmada para el {cita['fecha']} a las {cita['hora']}.")
     return {"id": body.id, "respuesta": "Cita confirmada y notificada."}
 
@@ -239,7 +246,14 @@ def cancel_appointment(body: AppointmentCancel):
     conn.close()
     # Notificar usuario
     if cita["usu_mail"]:
-        send_email(cita["usu_mail"], "Cita cancelada", f"Su cita ha sido cancelada. Motivo: {body.motivo}")
+        send_email(
+            cita["usu_mail"],
+            "Cita cancelada",
+            "email/reminder.html",
+            usuario=cita["usu_name"],
+            fecha_legible=str(cita["fecha"]),
+            hora=cita["hora"],
+        )
     if cita["usu_whatsapp"]:
         send_whatsapp(cita["usu_whatsapp"], f"Su cita ha sido cancelada. Motivo: {body.motivo}")
     return {"id": body.id, "respuesta": "Cita cancelada."}

--- a/services/scheduler-mcp/notifications.py
+++ b/services/scheduler-mcp/notifications.py
@@ -1,8 +1,15 @@
 import os
 import smtplib
 from email.message import EmailMessage
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-def send_email(to, subject, body):
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
+env = Environment(
+    loader=FileSystemLoader(TEMPLATES_DIR),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+def send_email(to: str, subject: str, template: str, **ctx):
     SMTP_HOST = os.getenv('SMTP_HOST', 'smtp.sendgrid.net')
     SMTP_PORT = int(os.getenv('SMTP_PORT', 587))
     SMTP_USER = os.getenv('SMTP_USER', 'apikey')
@@ -14,7 +21,9 @@ def send_email(to, subject, body):
     msg['Subject'] = subject
     msg['From'] = FROM
     msg['To'] = to
-    msg.set_content(body)
+    tmpl = env.get_template(template)
+    body = tmpl.render(**ctx)
+    msg.set_content(body, subtype='html')
     try:
         with smtplib.SMTP(SMTP_HOST, SMTP_PORT) as smtp:
             smtp.starttls()

--- a/services/scheduler-mcp/tasks.py
+++ b/services/scheduler-mcp/tasks.py
@@ -1,95 +1,72 @@
-from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail
-from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail
-import json
 import os
-import pytz
-import requests # Importar requests
-from datetime import datetime, timedelta
+from typing import Iterable
+import requests
+from psycopg2.extras import RealDictCursor
 
-# Configuración de WhatsApp (Meta Cloud API)
+from app import get_db
+from notifications import send_email
+
 META_PHONE_ID = os.getenv('META_PHONE_ID')
 META_TOKEN = os.getenv('META_TOKEN')
 
-def send_reminder():
-    """Enviar recordatorios un día antes de la cita"""
-    # Leer citas desde el archivo JSON
-    with open('databases/appointments.json', 'r') as f:
-        citas = json.load(f)['citas']
-    
-    # Obtener fecha de mañana en Santiago de Chile
-    tomorrow = datetime.now(pytz.timezone('America/Santiago')) + timedelta(days=1)
-    tomorrow_str = tomorrow.strftime("%Y-%m-%d")
-    
-    for cita in citas:
-        if (cita['fecha'] == tomorrow_str and 
-            cita['AVLB'] == 0 and  # Ocupado
-            cita['USU_CONF'] == 1):  # Confirmado
-        
-            # Enviar correo
-            send_email(cita)
-            
-            # Enviar WhatsApp (si hay número)
-            if cita.get('USU_WHATSAPP'):
-                send_whatsapp(cita)
 
-def send_email(cita):
-    """Enviar correo de recordatorio usando SendGrid"""
-    message = Mail(
-        from_email=os.getenv('SENDER_EMAIL'),
-        to_emails=cita['USU_MAIL'],
-        subject='Recordatorio de cita municipal',
-        plain_text_content=f"""
-        Estimado {cita['USU_NAME']},
-
-        Recordatorio: Su cita está programada para mañana {cita['fecha']} 
-        en el horario {cita['hora']} con el funcionario {cita['FUNC']}.
-
-        Código de cita: {cita['ID']}
-        Funcionario: {cita['FUNC']} ({cita['COD_FUNC']})
-        """
+def fetch_tomorrow_confirmed(conn) -> Iterable[dict]:
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute(
+        """SELECT * FROM appointments
+           WHERE fecha = CURRENT_DATE + INTERVAL '1 day'
+             AND avlb=0 AND usu_conf=1"""
     )
-    try:
-        sg = SendGridAPIClient(os.getenv('SENDGRID_API_KEY'))
-        sg.send(message)
-    except Exception as e:
-        print(f"Error al enviar correo a {cita['USU_MAIL']}: {str(e)}")
+    return cur.fetchall()
+
 
 def send_whatsapp(cita):
-    """Enviar mensaje de WhatsApp usando Meta Cloud API"""
     if not META_PHONE_ID or not META_TOKEN:
-        print("Error: Faltan variables de entorno META_PHONE_ID o META_TOKEN")
         return
     try:
-        phone_number = cita['USU_WHATSAPP'].replace('+', '')
+        phone_number = cita['usu_whatsapp'].replace('+', '')
         url = f"https://graph.facebook.com/v19.0/{META_PHONE_ID}/messages"
         payload = {
             "messaging_product": "whatsapp",
             "to": phone_number,
             "type": "text",
-            "text": { "body": f"Recordatorio: Su cita es mañana {cita['fecha']} a las {cita['hora']} con {cita['FUNC']}." }
+            "text": {"body": f"Recordatorio: Su cita es mañana {cita['fecha']} a las {cita['hora']} con {cita['func']}."}
         }
         headers = {
             "Authorization": f"Bearer {META_TOKEN}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
-        response = requests.post(url, json=payload, headers=headers)
+        requests.post(url, json=payload, headers=headers)
     except Exception as e:
-        print(f"Error al enviar WhatsApp a {cita['USU_WHATSAPP']}: {str(e)}")
+        print(f"Error al enviar WhatsApp a {cita['usu_whatsapp']}: {e}")
 
-def setup_scheduler():
-    """Configurar el scheduler de APScheduler"""
-    from apscheduler.schedulers.background import BackgroundScheduler
-    scheduler = BackgroundScheduler()
-    
-    # Programar el recordatorio diario a las 9:00 AM
-    scheduler.add_job(
-        send_reminder,
-        'cron',
-        hour=9,  # Hora en zona horaria de Santiago
-        minute=0,
-        id='daily_reminder'
-    )
-    
-    scheduler.start()
+
+def send_reminder(dry: bool = False):
+    conn = get_db()
+    citas = fetch_tomorrow_confirmed(conn)
+    conn.close()
+    count = 0
+    for cita in citas:
+        if not dry:
+            send_email(
+                cita['usu_mail'],
+                'Recordatorio de cita municipal',
+                'email/reminder.html',
+                usuario=cita['usu_name'],
+                fecha_legible=str(cita['fecha']),
+                hora=cita['hora'],
+            )
+            if cita.get('usu_whatsapp'):
+                send_whatsapp(cita)
+        count += 1
+    if dry:
+        print(f"{count} correos de recordatorio generados")
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry', action='store_true', help='No enviar correos')
+    args = parser.parse_args()
+    send_reminder(dry=args.dry)

--- a/services/scheduler-mcp/templates/email/confirm.html
+++ b/services/scheduler-mcp/templates/email/confirm.html
@@ -1,0 +1,3 @@
+<p>Hola {{ usuario }},</p>
+<p>Tu cita ha sido confirmada para el {{ fecha_legible }} a las {{ hora }}.</p>
+<p>Gracias por usar nuestros servicios.</p>

--- a/services/scheduler-mcp/templates/email/reminder.html
+++ b/services/scheduler-mcp/templates/email/reminder.html
@@ -1,0 +1,3 @@
+<p>Estimado/a {{ usuario }},</p>
+<p>Le recordamos que tiene una cita agendada para mañana {{ fecha_legible }} a las {{ hora }}.</p>
+<p>Por favor no olvide asistir.</p>


### PR DESCRIPTION
## Summary
- add jinja-based send_email in `notifications.py`
- implement DB-based reminder logic and CLI in `tasks.py`
- update scheduler `app.py` to use HTML templates
- provide reminder and confirmation templates

## Testing
- `pytest tests/test_available_endpoint.py tests/test_datetime_utils.py`
- `POSTGRES_PORT=5432 TESTING=1 python services/scheduler-mcp/tasks.py --dry`

------
https://chatgpt.com/codex/tasks/task_e_686c497a52f0832faf8f12151c4a9e96