### PR TITLE
Add next week story and confirm flow test

### DIFF
--- a/docs/stories.yml
+++ b/docs/stories.yml
@@ -1,0 +1,9 @@
+version: "3.1"
+stories:
+- story: Consultar disponibilidad próxima semana
+  steps:
+  - user: |
+      ¿Hay horas disponibles la próxima semana?
+  - action: action_listar_horas_disponibles
+  - bot: |
+      Estas son las horas disponibles para la próxima semana.

--- a/mcp-core/classification_utils.py
+++ b/mcp-core/classification_utils.py
@@ -1,0 +1,10 @@
+
+def classify_reclamo_response(text: str) -> str:
+    t = text.lower().strip()
+    if any(word in t for word in ['?', 'saber']):
+        return 'question'
+    if t.startswith('si') or t.startswith('sí') or ' sí' in t:
+        return 'affirmative'
+    if t.startswith('no') or ' no' in t:
+        return 'negative'
+    return 'unknown'

--- a/tests/test_confirm_flow.py
+++ b/tests/test_confirm_flow.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+import sys
+from datetime import date
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+os.environ["POSTGRES_PORT"] = "5432"
+os.environ["TESTING"] = "1"
+
+base_dir = os.path.join("services", "scheduler-mcp")
+sys.path.insert(0, base_dir)
+
+spec = importlib.util.spec_from_file_location("scheduler_mcp", os.path.join(base_dir, "app.py"))
+scheduler_mcp = importlib.util.module_from_spec(spec)
+sys.modules["scheduler_mcp"] = scheduler_mcp
+spec.loader.exec_module(scheduler_mcp)
+import importlib as _importlib
+scheduler_mcp.notifications = _importlib.import_module("notifications")
+app = scheduler_mcp.app
+
+client = TestClient(app)
+
+class DummyConn:
+    def __init__(self, rows):
+        self.rows = rows
+    def cursor(self, *a, **k):
+        outer = self
+        class C:
+            def execute(self, *a, **k):
+                pass
+            def fetchone(self_inner):
+                return outer.rows.pop(0) if outer.rows else None
+            def fetchall(self_inner):
+                return outer.rows
+        return C()
+    def commit(self):
+        pass
+    def close(self):
+        pass
+
+def test_reserve_and_confirm(monkeypatch):
+    slot = {"id": "abc123"}
+    monkeypatch.setattr(scheduler_mcp, "get_db", lambda: DummyConn([slot.copy()]))
+
+    payload = {
+        "func": "funcionario",
+        "cod_func": "123",
+        "motiv": "",
+        "usu_name": "Juan",
+        "usu_mail": "juan@example.com",
+        "usu_whatsapp": "+123456789",
+        "fecha": date.today().isoformat(),
+        "hora": "10:00"
+    }
+    r = client.post("/appointments/reserve", json=payload)
+    assert r.status_code == 200
+
+    appt = {
+        "id": "abc123",
+        "avlb": 0,
+        "usu_conf": 0,
+        "usu_mail": "juan@example.com",
+        "usu_whatsapp": "+123456789",
+        "func": "funcionario",
+        "usu_name": "Juan",
+        "fecha": date.today(),
+        "hora": "10:00"
+    }
+    monkeypatch.setattr(scheduler_mcp, "get_db", lambda: DummyConn([appt.copy()]))
+    with patch('scheduler_mcp.notifications.send_email') as mock_mail:
+        scheduler_mcp.send_email = scheduler_mcp.notifications.send_email
+        r = client.post("/appointments/confirm", json={"id": "abc123"})
+        assert r.status_code == 200
+        mock_mail.assert_called_once()


### PR DESCRIPTION
## Summary
- add new story for scheduler availability
- implement simple classification utilities stub
- create test for reservation confirmation flow using email patch

## Testing
- `pytest tests/test_confirm_flow.py -q`
- `pip install rasa==3.5.1` *(fails: Requires-Python <3.8)*

------
https://chatgpt.com/codex/tasks/task_e_686c4cf82a0c832fa28073daa20de564