### PR TITLE
Implement scheduler flow timestamp and relative date handling

### DIFF
--- a/mcp-core/utils/datetime_utils.py
+++ b/mcp-core/utils/datetime_utils.py
@@ -1,5 +1,6 @@
-from datetime import datetime
+from datetime import datetime, date, timedelta
 import re
+from typing import Optional
 from dateparser.search import search_dates
 
 
@@ -21,3 +22,30 @@ def parse_nl_datetime(text: str, base_dt: datetime) -> tuple[datetime | None, st
             minute = int(m.group(2) or 0)
             dt = dt.replace(hour=hour, minute=minute, second=0, microsecond=0)
     return dt, match_text
+
+
+WEEKDAYS = {
+    "lunes": 0,
+    "martes": 1,
+    "miércoles": 2,
+    "miercoles": 2,
+    "jueves": 3,
+    "viernes": 4,
+    "sábado": 5,
+    "sabado": 5,
+    "domingo": 6,
+}
+
+
+def compute_relative_date(base: date, texto: str) -> Optional[date]:
+    """Calcula una fecha relativa a partir de un texto y un día base."""
+    for name, wd in WEEKDAYS.items():
+        if name in texto.lower():
+            hoy_wd = base.weekday()
+            diff = (wd - hoy_wd + 7) % 7
+            if "próximo" in texto.lower() and diff == 0:
+                diff = 7
+            elif diff == 0:
+                pass
+            return base + timedelta(days=diff)
+    return None


### PR DESCRIPTION
## Summary
- track scheduler flow start datetime in context when entering scheduler mode
- compute relative appointment dates with new helper
- adjust appointment slot handling to use new date logic

## Testing
- `pytest tests/test_datetime_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686d5ab02668832f9c1ac45984b0afcf