### PR TITLE
Limit scheduling to current month

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -19,7 +19,11 @@ import unicodedata
 from utils.text import normalize_text
 from llama_client import LlamaClient
 from zoneinfo import ZoneInfo
-from utils.datetime_utils import parse_nl_datetime, compute_relative_date
+from utils.datetime_utils import (
+    parse_nl_datetime,
+    compute_relative_date,
+    compute_last_business_day,
+)
 from rapidfuzz import fuzz
 from datetime import datetime
 
@@ -1371,6 +1375,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
             flow_start_dt = datetime.now(tz=SANTIAGO_TZ)
         else:
             flow_start_dt = datetime.fromisoformat(flow_start)
+        flow_start_month = ctx.get("flow_start_month", flow_start_dt.month)
         texto = user_text
 
         m = re.search(r"(\d{1,2})(?::| h| horas)?", texto)
@@ -1381,6 +1386,15 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         fecha_obj = compute_relative_date(flow_start_dt.date(), texto)
         if not fecha_obj:
             return {"answer": "No entendí la fecha. ¿Podrías decirlo diferente?", "pending": True}
+        if fecha_obj.month != flow_start_month:
+            ultimo_habil = compute_last_business_day(flow_start_dt)
+            return {
+                "answer": (
+                    f"Solo puedo agendar durante {flow_start_dt.strftime('%B')} de {flow_start_dt.year}. "
+                    f"¿Te parece el último día hábil del mes, {ultimo_habil.isoformat()}?"
+                ),
+                "pending": True,
+            }
         fecha_str = fecha_obj.isoformat()
 
         payload = {"fecha": fecha_str, "hora_rango": f"{hora_str}-"}
@@ -1859,8 +1873,13 @@ def orchestrate(
                 context_manager.set_current_flow(sid, "scheduler")
                 context_manager.update_pending_field(sid, "bloque_cita")
                 # --- Nuevo: registrar inicio de flujo de agenda ---
+                now_dt = datetime.now(tz=SANTIAGO_TZ)
                 context_manager.update_context_data(
-                    sid, {"flow_start_datetime": datetime.now(tz=SANTIAGO_TZ).isoformat()}
+                    sid,
+                    {
+                        "flow_start_datetime": now_dt.isoformat(),
+                        "flow_start_month": now_dt.month,
+                    },
                 )
                 # ----------- Fin parche modo cita -----------
                 context_manager.inc_attempts(sid, flow)

--- a/mcp-core/utils/datetime_utils.py
+++ b/mcp-core/utils/datetime_utils.py
@@ -49,3 +49,14 @@ def compute_relative_date(base: date, texto: str) -> Optional[date]:
                 pass
             return base + timedelta(days=diff)
     return None
+
+
+def compute_last_business_day(ref: datetime) -> date:
+    """Return the last business day of the month for the given date."""
+    # Start at the last calendar day of the month
+    next_month = ref.replace(day=28) + timedelta(days=4)
+    last_day = next_month - timedelta(days=next_month.day)
+    # Move backwards until it's not Saturday/Sunday
+    while last_day.weekday() >= 5:
+        last_day -= timedelta(days=1)
+    return last_day

--- a/tests/test_datetime_utils.py
+++ b/tests/test_datetime_utils.py
@@ -25,3 +25,9 @@ def test_fecha_dia_mes():
     base = datetime(2025, 7, 7)
     dt, _ = datetime_utils.parse_nl_datetime('24/08', base)
     assert dt == datetime(2025, 8, 24, 0, 0, tzinfo=dt.tzinfo)
+
+
+def test_last_business_day():
+    base = datetime(2025, 8, 15)
+    last = datetime_utils.compute_last_business_day(base)
+    assert last == datetime(2025, 8, 29).date()


### PR DESCRIPTION
## Summary
- add `compute_last_business_day` helper
- track `flow_start_month` when beginning the scheduler flow
- refuse scheduling outside the starting month and offer last business day
- test `compute_last_business_day`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686d7b3cc614832f932f596de0729117