### PR TITLE
Limit scheduler to current month

### DIFF
--- a/mcp-core/utils/datetime_utils.py
+++ b/mcp-core/utils/datetime_utils.py
@@ -59,4 +59,5 @@ def compute_last_business_day(ref: datetime) -> date:
     # Move backwards until it's not Saturday/Sunday
     while last_day.weekday() >= 5:
         last_day -= timedelta(days=1)
-    return last_day
+    # Return only the date component
+    return last_day.date()

--- a/tests/test_orchestrator_cancel.py
+++ b/tests/test_orchestrator_cancel.py
@@ -36,12 +36,14 @@ def test_cancel_reclamo_flow():
     assert r.status_code == 200
     data = r.json()
     sid = data['session_id']
-    assert 'registrarlo' in data['respuesta'].lower()
+    first_msg = data.get('respuesta') or ' '.join(data.get('respuestas', []))
+    assert 'registrarlo' in first_msg.lower()
 
     r = client.post('/orchestrate', json={'pregunta': 'sí', 'session_id': sid})
     assert r.status_code == 200
     data = r.json()
-    assert '¿cómo te llamas' in data['respuesta'].lower()
+    second_msg = data.get('respuesta') or ' '.join(data.get('respuestas', []))
+    assert '¿cómo te llamas' in second_msg.lower()
 
     r = client.post('/orchestrate', json={'pregunta': 'Juan Perez', 'session_id': sid})
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- ensure `compute_last_business_day` returns a date
- update orchestrator cancel test to accept new multi-message response

## Testing
- `pytest tests/test_datetime_utils.py -q`
- `pytest services/llm_docs-mcp/test_tools.py -q`
- `pytest tests/test_tramites_menu.py -q`
- `pytest tests/test_orchestrator_cancel.py::test_cancel_reclamo_flow -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.text')*

------
https://chatgpt.com/codex/tasks/task_e_686d7d5db4ac832f8219e161cccefe3f