### PR TITLE
Add audit logs for scheduler

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1629,7 +1629,9 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         }
 
         # 4) Llamar y normalizar respuesta
+        print(f"[AUDIT] payload listar_horas: {payload}", flush=True)
         raw = call_tool_microservice("scheduler-listar_horas_disponibles", payload)
+        print(f"[AUDIT] raw response listar_horas: {raw}", flush=True)
         if isinstance(raw, dict) and "data" in raw:
             bloques = raw["data"]
         elif isinstance(raw, list):

--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -2,6 +2,7 @@ import os
 import re
 from datetime import date, datetime
 from typing import Optional
+import logging
 
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -43,6 +44,8 @@ def get_db():
     return conn
 
 app = FastAPI()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 # Configurar CORS
 app.add_middleware(
@@ -165,6 +168,9 @@ def list_available(
     # ahora TRUE = libre, FALSE = no confirmada
     query = "SELECT * FROM appointments WHERE disponible = TRUE AND confirmada = FALSE"
     params = []
+    logger.debug(
+        f"[AUDIT] listar_horas recibidas: from={from_date}, to={to_date}"
+    )
     if from_date and to_date:
         query += " AND fecha BETWEEN %s AND %s"
         params.extend([from_date, to_date])
@@ -174,6 +180,7 @@ def list_available(
     query += " ORDER BY fecha, hora"
     cur.execute(query, tuple(params))
     citas = cur.fetchall()
+    logger.debug(f"[AUDIT] filas devueltas: {citas}")
     conn.close()
     return {"disponibles": citas}
 


### PR DESCRIPTION
## Summary
- add audit printouts before and after calling scheduler list microservice
- log received parameters and DB results inside scheduler-mcp service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f0c3c89b4832fb4755af6c3802a2c