### PR TITLE
Fix hour column reference in scheduler

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -212,7 +212,8 @@ def list_available(
     elif from_date:
         query += " AND fecha >= %s"
         params.append(from_date)
-    query += " ORDER BY fecha, hora"
+    # ordenar cronológicamente por fecha y hora_rango
+    query += " ORDER BY fecha, hora_rango"
     cur.execute(query, tuple(params))
     citas = cur.fetchall()
     logger.debug(f"[AUDIT] filas devueltas: {citas}")


### PR DESCRIPTION
## Summary
- correct SQL query in `/appointments/available` to order by `hora_rango` instead of the missing `hora` column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686f2148ea14832f8cb5e9a10041de16