### PR TITLE
Fix scheduler flow datetime usage

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1453,7 +1453,6 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         bloques = raw.get("disponibles", []) if isinstance(raw, dict) else []
 
         # Buscar el bloque cuyo rango contenga la hora solicitada
-        from datetime import datetime
         hora_user_dt = datetime.strptime(hora_str, "%H:%M").time()
         bloque_match = None
         for b in bloques:
@@ -1656,7 +1655,6 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         bloques = raw.get("disponibles", []) if isinstance(raw, dict) else []
 
         # 5) Filtrar bloques cuyo rango contenga hora_user (rango semi-abierto)
-        from datetime import datetime
         hora_user_dt = datetime.strptime(hora_str, "%H:%M").time()
         bloque_match = None
         for b in bloques:


### PR DESCRIPTION
## Summary
- remove redundant local `datetime` imports in `_handle_scheduler_flow`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.text')*

------
https://chatgpt.com/codex/tasks/task_e_687006280f34832fa24b9fb218cb6821