### PR TITLE
chore(audit): structured tracing for scheduler debug

### DIFF
--- a/mcp-core/utils/audit.py
+++ b/mcp-core/utils/audit.py
@@ -1,0 +1,36 @@
+import os
+import functools
+import json
+import logging
+import inspect
+
+logger = logging.getLogger("audit")
+ENABLED = os.getenv("AUDIT_SCHEDULER_DEBUG", "false").lower() == "true"
+
+
+def audit_step(label):
+    def wrapper(fn):
+        if not ENABLED:
+            return fn
+
+        @functools.wraps(fn)
+        def inner(*args, **kw):
+            trace_id = kw.get("trace_id")
+            if trace_id is None and args:
+                trace_id = getattr(args[0], "sid", None)
+            arg_names = inspect.getfullargspec(fn).args
+            payload = {
+                "step": label,
+                "trace_id": trace_id,
+                "args": {k: v for k, v in zip(arg_names, args)},
+                "kwargs": kw,
+            }
+            logger.debug(json.dumps(payload, default=str))
+            out = fn(*args, **kw)
+            payload.update({"return": out})
+            logger.debug(json.dumps(payload, default=str))
+            return out
+
+        return inner
+
+    return wrapper

--- a/mcp-core/utils/parser.py
+++ b/mcp-core/utils/parser.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import Tuple, Optional
+import re
+
+from .datetime_utils import parse_nl_datetime
+from .audit import audit_step
+
+
+@audit_step("parse_date_time")
+def parse_date_time(text: str, base_dt: Optional[datetime] = None, trace_id: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
+    base_dt = base_dt or datetime.now()
+    dt, _ = parse_nl_datetime(text, base_dt)
+    if dt:
+        return dt.strftime("%Y-%m-%d"), dt.strftime("%H:%M")
+    # fallback simple ISO pattern
+    m = re.search(r"(\d{4}-\d{2}-\d{2})", text)
+    fecha = m.group(1) if m else None
+    mh = re.search(r"(\d{1,2}:\d{2})", text)
+    hora = mh.group(1) if mh else None
+    return fecha, hora

--- a/services/scheduler-mcp/repository.py
+++ b/services/scheduler-mcp/repository.py
@@ -1,0 +1,37 @@
+from datetime import time, date
+from psycopg2.extras import RealDictCursor
+from .app import get_db
+import os
+import sys
+
+# Ensure mcp-core is on path for audit utilities
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'mcp-core'))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+try:
+    from utils.audit import audit_step
+except ImportError:
+    from importlib import import_module
+    audit_step = import_module('mcp_utils.audit').audit_step
+
+
+@audit_step("build_sql_pattern")
+def build_sql_pattern(hora_user: time, trace_id=None) -> str:
+    hora_fmt = hora_user.strftime("%H:%M")
+    return f"{hora_fmt}-%"
+
+
+@audit_step("get_available_blocks")
+def get_available_blocks(fecha: date, pattern: str, trace_id=None):
+    conn = get_db()
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    query = (
+        "SELECT * FROM appointments "
+        "WHERE fecha = %s AND hora_rango LIKE %s "
+        "AND disponible = TRUE AND confirmada = FALSE "
+        "ORDER BY hora_rango"
+    )
+    cur.execute(query, (fecha.isoformat(), pattern))
+    rows = cur.fetchall()
+    conn.close()
+    return rows

--- a/services/scheduler-mcp/service.py
+++ b/services/scheduler-mcp/service.py
@@ -1,0 +1,25 @@
+from datetime import datetime, time
+from typing import Iterable, Optional, Dict
+import os
+import sys
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'mcp-core'))
+if BASE_DIR not in sys.path:
+    sys.path.insert(0, BASE_DIR)
+
+try:
+    from utils.audit import audit_step
+except ImportError:
+    from importlib import import_module
+    audit_step = import_module('mcp_utils.audit').audit_step
+
+
+@audit_step("select_exact_block")
+def select_exact_block(bloques: Iterable[Dict], hora_user: time, trace_id=None) -> Optional[Dict]:
+    for b in bloques:
+        start_str, end_str = b["hora_rango"].split("-")
+        start_dt = datetime.strptime(start_str, "%H:%M").time()
+        end_dt = datetime.strptime(end_str, "%H:%M").time()
+        if start_dt <= hora_user < end_dt:
+            return b
+    return None

--- a/tests/test_audit_flow.py
+++ b/tests/test_audit_flow.py
@@ -1,0 +1,89 @@
+import importlib.util
+import os
+import sys
+import json
+import types
+from datetime import datetime, date
+import fakeredis
+
+os.environ["AUDIT_SCHEDULER_DEBUG"] = "true"
+os.environ["LOG_LEVEL"] = "DEBUG"
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
+# mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *a, **k):
+        pass
+    def __call__(self, *a, **k):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+# import parser
+base_dir = os.path.abspath(os.path.join('services', 'scheduler-mcp'))
+sys.path.insert(0, os.path.abspath('mcp-core'))
+sys.path.insert(0, base_dir)
+mcp_utils = types.ModuleType('mcp_utils')
+mcp_utils.__path__ = [os.path.abspath('mcp-core/utils')]
+sys.modules['mcp_utils'] = mcp_utils
+parser_spec = importlib.util.spec_from_file_location('mcp_utils.parser', os.path.join('mcp-core','utils','parser.py'))
+parser = importlib.util.module_from_spec(parser_spec)
+parser_spec.loader.exec_module(parser)
+
+# import scheduler modules
+pkg = types.ModuleType('scheduler_mcp')
+pkg.__path__ = [base_dir]
+sys.modules['scheduler_mcp'] = pkg
+# create dummy app module providing get_db
+app_stub = types.ModuleType('scheduler_mcp.app')
+def get_db():
+    class Dummy:
+        def cursor(self, *a, **k):
+            class C:
+                def execute(self, *a, **k):
+                    pass
+                def fetchall(self_inner):
+                    return [
+                        {"id": "C0028", "fecha": os.environ.get("TEST_FECHA"), "hora_rango": "10:00-10:30", "disponible": True, "confirmada": False}
+                    ]
+            return C()
+        def close(self):
+            pass
+    return Dummy()
+app_stub.get_db = get_db
+sys.modules['scheduler_mcp.app'] = app_stub
+repo_spec = importlib.util.spec_from_file_location('scheduler_mcp.repository', os.path.join(base_dir, 'repository.py'))
+repository = importlib.util.module_from_spec(repo_spec)
+sys.modules['scheduler_mcp.repository'] = repository
+repo_spec.loader.exec_module(repository)
+service_spec = importlib.util.spec_from_file_location('scheduler_mcp.service', os.path.join(base_dir, 'service.py'))
+service = importlib.util.module_from_spec(service_spec)
+sys.modules['scheduler_mcp.service'] = service
+service_spec.loader.exec_module(service)
+
+sys.modules['utils'] = mcp_utils
+
+orch_spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(orch_spec)
+orch_spec.loader.exec_module(orchestrator)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+
+def test_audit_tracing(caplog):
+    caplog.set_level(logging.DEBUG, logger="audit")
+    sid = "debug-17-jul-10"
+    os.environ["TEST_FECHA"] = "2025-07-17"
+    fecha, hora = parser.parse_date_time("17-07-2025 10:00", trace_id=sid)
+    pattern = repository.build_sql_pattern(datetime.strptime(hora, "%H:%M").time(), trace_id=sid)
+    bloques = repository.get_available_blocks(date.fromisoformat(fecha), pattern, trace_id=sid)
+    bloque = service.select_exact_block(bloques, datetime.strptime(hora, "%H:%M").time(), trace_id=sid)
+    orchestrator.format_response({"answer": "ok"}, sid, trace_id=sid)
+    steps = [json.loads(record.message)["step"] for record in caplog.records if sid in record.message]
+    assert set(steps) == {"parse_date_time", "build_sql_pattern", "get_available_blocks", "select_exact_block", "render_response"}


### PR DESCRIPTION
## Summary
- add `audit_step` decorator for debug tracing
- create parser and scheduler helpers instrumented with audit logs
- wire orchestrator and scheduler service to use new audit utilities
- add regression test for tracing flow

## Testing
- `pytest tests/test_audit_flow.py -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6870600c1aac832fb91a3786869904df