### PR TITLE
Fix scheduler search and test db

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -22,7 +22,9 @@ from utils.parser import parse_date_time
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import importlib.util
-service_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'services', 'scheduler-mcp', 'service.py'))
+service_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'services', 'scheduler-mcp', 'service.py')
+)
 _spec = importlib.util.spec_from_file_location('scheduler_service', service_path)
 _svc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_svc)
@@ -1463,7 +1465,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         ctx["bloque_cita"]["hora_rango"] = f"{hora_str}-%"
         save_session(sid, ctx)
         # Obtener todos los bloques disponibles del día
-        payload = {"fecha": fecha_str}
+        payload = {"fecha": fecha_str, "hora": hora_str}
         raw = call_tool_microservice("scheduler-listar_horas_disponibles", payload)
         bloques = raw.get("disponibles", []) if isinstance(raw, dict) else []
 
@@ -1665,7 +1667,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         save_session(sid, ctx)
 
         # 4) Llamar al scheduler pidiendo todos los bloques del día
-        payload = {"fecha": fecha_str}
+        payload = {"fecha": fecha_str, "hora": hora_str}
         raw = call_tool_microservice("scheduler-listar_horas_disponibles", payload)
         bloques = raw.get("disponibles", []) if isinstance(raw, dict) else []
 

--- a/services/scheduler-mcp/db.py
+++ b/services/scheduler-mcp/db.py
@@ -7,11 +7,37 @@ DB_DSN = os.getenv(
     "postgresql://postgres:postgres@postgres:5432/munbot"  # Ajusta al DSN real si es necesario
 )
 
-_pool = SimpleConnectionPool(minconn=1, maxconn=10, dsn=DB_DSN)
+TESTING = os.getenv("TESTING") == "1" or os.getenv("AUDIT_SCHEDULER_DEBUG") == "true"
 
-def get_db():
-    """Devuelve una conexión del pool."""
-    return _pool.getconn()
+if not TESTING:
+    _pool = SimpleConnectionPool(minconn=1, maxconn=10, dsn=DB_DSN)
 
-def put_db(conn):
-    _pool.putconn(conn)
+    def get_db():
+        """Devuelve una conexión del pool."""
+        return _pool.getconn()
+
+    def put_db(conn):
+        _pool.putconn(conn)
+else:
+    class _Dummy:
+        def cursor(self, *a, **k):
+            class C:
+                def execute(self, *a, **k):
+                    pass
+
+                def fetchall(self):
+                    return []
+
+                def fetchone(self):
+                    return None
+
+            return C()
+
+        def close(self):
+            pass
+
+    def get_db():
+        return _Dummy()
+
+    def put_db(conn):
+        pass


### PR DESCRIPTION
## Summary
- send time parameter when querying scheduler
- adjust path to scheduler service module
- return dummy DB connection when running tests

## Testing
- `pytest -q` *(fails: TypeError with dummy connection, missing build_sql_pattern, request 400 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68718cf05f1c832faaeb1cae60aa2160