### PR TITLE
Add trace_id propagation and SQL audit logging

### DIFF
--- a/tests/test_audit_flow.py
+++ b/tests/test_audit_flow.py
@@ -86,4 +86,12 @@ def test_audit_tracing(caplog):
     bloque = service.select_exact_block(bloques, datetime.strptime(hora, "%H:%M").time(), trace_id=sid)
     orchestrator.format_response({"answer": "ok"}, sid, trace_id=sid)
     steps = [json.loads(record.message)["step"] for record in caplog.records if sid in record.message]
-    assert set(steps) == {"parse_date_time", "build_sql_pattern", "get_available_blocks", "select_exact_block", "render_response"}
+    assert set(steps) == {
+        "parse_date_time",
+        "build_sql_pattern",
+        "get_available_blocks",
+        "execute_sql",
+        "rows_fetched",
+        "select_exact_block",
+        "render_response",
+    }


### PR DESCRIPTION
## Summary
- propagate `trace_id` through scheduler tool flow
- audit SQL queries executed in repository
- log fetched rows for traceability
- update audit flow tests to include new audit steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687297b95264832f86164dcb1ea6b1ff