### PR TITLE
Fix parse_date_time for ambiguous hour phrases

### DIFF
--- a/mcp-core/utils/parser.py
+++ b/mcp-core/utils/parser.py
@@ -9,8 +9,12 @@ from .audit import audit_step
 @audit_step("parse_date_time")
 def parse_date_time(text: str, base_dt: Optional[datetime] = None, trace_id: Optional[str] = None) -> Tuple[Optional[str], Optional[str]]:
     base_dt = base_dt or datetime.now()
-    dt, _ = parse_nl_datetime(text, base_dt)
+    dt, match = parse_nl_datetime(text, base_dt)
     if dt:
+        if match:
+            m = match.lower().strip()
+            if re.fullmatch(r"(una|1) hora", m) and not re.search(r"\b(en|dentro de)\s+una hora\b", text.lower()):
+                return None, None
         return dt.strftime("%Y-%m-%d"), dt.strftime("%H:%M")
     # fallback simple ISO pattern
     m = re.search(r"(\d{4}-\d{2}-\d{2})", text)

--- a/tests/test_parse_date_time_ignore.py
+++ b/tests/test_parse_date_time_ignore.py
@@ -1,0 +1,53 @@
+import importlib.util
+import os
+import sys
+import types
+import fakeredis
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["FAQ_DB_PATH"] = os.path.join('mcp-core', 'databases', 'faq_respuestas.json')
+os.environ["PROMPTS_PATH"] = os.path.join('mcp-core', 'prompts')
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("FAQ_DB_PATH", None)
+os.environ.pop("PROMPTS_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+
+def test_parse_generic_phrase():
+    fecha, hora = orchestrator.parse_date_time('Quiero pedir una hora')
+    assert fecha is None and hora is None
+
+
+def test_orchestrator_prompts_date(monkeypatch):
+    captured = {}
+    def fake_call(tool, payload):
+        captured['called'] = True
+        return {}
+    monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
+    resp = orchestrator.orchestrate('Quiero pedir una hora')
+    assert 'fecha' in resp['respuesta'].lower()
+    assert 'called' not in captured
+
+def test_parse_explicit_datetime():
+    base = orchestrator.datetime(2025, 7, 7, 12, 0)
+    fecha, hora = orchestrator.parse_date_time('Quiero una cita el 14 de Julio a las 10:00', base_dt=base)
+    assert fecha == '2025-07-14'
+    assert hora == '10:00'


### PR DESCRIPTION
## Summary
- avoid interpreting generic phrases like "una hora" as dates in `parse_date_time`
- add tests covering the new behaviour

## Testing
- `pytest tests/test_parse_date_time_ignore.py -q`
- `pytest -q` *(fails: ImportError: email-validator and utils.text issues)*

------
https://chatgpt.com/codex/tasks/task_e_6872fdc1c554832fb5c37bb756c8829b