### PR TITLE
Fix DB connection handling for scheduler

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -25,7 +25,7 @@ DB_NAME = os.getenv("POSTGRES_DB")
 DB_USER = os.getenv("POSTGRES_USER")
 DB_PASS = os.getenv("POSTGRES_PASSWORD")
 
-from db import get_db
+from db import get_db, put_db
 
 
 def get_available_block(fecha: date, hora: dtime, trace_id: str | None = None):
@@ -218,13 +218,19 @@ def list_available(request: Request):
         rows = get_available_blocks(date.fromisoformat(fecha), pattern)
     elif desde and hasta:
         conn = get_db()
-        cur = conn.cursor(cursor_factory=RealDictCursor)
-        cur.execute(
-            "SELECT * FROM appointments WHERE fecha BETWEEN %s AND %s",
-            (desde, hasta),
-        )
-        rows = cur.fetchall()
-        conn.close()
+        try:
+            cur = conn.cursor(cursor_factory=RealDictCursor)
+            try:
+                cur.execute(
+                    "SELECT * FROM appointments WHERE fecha BETWEEN %s AND %s",
+                    (desde, hasta),
+                )
+                rows = cur.fetchall()
+            finally:
+                if hasattr(cur, "close"):
+                    cur.close()
+        finally:
+            put_db(conn)
     else:
         return {"disponibles": []}
     out = []
@@ -239,28 +245,38 @@ def list_available(request: Request):
 def reserve_appointment(appt: AppointmentCreate):
     """Reservar una cita"""
     conn = get_db()
-    cur = conn.cursor(cursor_factory=RealDictCursor)
-    # Busca slot disponible
-    cur.execute(
-        "SELECT * FROM appointments "
-        "WHERE funcionario_codigo=%s AND fecha=%s AND hora_inicio=%s AND hora_fin=%s "
-        "AND disponible = TRUE AND confirmada = FALSE",
-        (appt.cod_func, appt.fecha, appt.hora_inicio.strftime('%H:%M'), appt.hora_fin.strftime('%H:%M'))
-    )
-    slot = cur.fetchone()
-    if not slot:
-        conn.close()
-        raise HTTPException(status_code=404, detail="Slot no disponible o ya reservado")
-    # Reserva (marca como no disponible, confirma usuario)
-    cur.execute(
-        "UPDATE appointments "
-        "SET disponible = FALSE, confirmada = FALSE, "
-        "    usuario_nombre = %s, usuario_email = %s, usuario_whatsapp = %s, motivo = %s "
-        "WHERE id = %s",
-        (appt.usu_name, appt.usu_mail, appt.usu_whatsapp, appt.motiv, slot["id"])
-    )
-    conn.commit()
-    conn.close()
+    try:
+        cur = conn.cursor(cursor_factory=RealDictCursor)
+        try:
+            # Busca slot disponible
+            cur.execute(
+                "SELECT * FROM appointments "
+                "WHERE funcionario_codigo=%s AND fecha=%s AND hora_inicio=%s AND hora_fin=%s "
+                "AND disponible = TRUE AND confirmada = FALSE",
+                (
+                    appt.cod_func,
+                    appt.fecha,
+                    appt.hora_inicio.strftime('%H:%M'),
+                    appt.hora_fin.strftime('%H:%M'),
+                ),
+            )
+            slot = cur.fetchone()
+            if not slot:
+                raise HTTPException(status_code=404, detail="Slot no disponible o ya reservado")
+            # Reserva (marca como no disponible, confirma usuario)
+            cur.execute(
+                "UPDATE appointments "
+                "SET disponible = FALSE, confirmada = FALSE, "
+                "    usuario_nombre = %s, usuario_email = %s, usuario_whatsapp = %s, motivo = %s "
+                "WHERE id = %s",
+                (appt.usu_name, appt.usu_mail, appt.usu_whatsapp, appt.motiv, slot["id"]),
+            )
+            conn.commit()
+        finally:
+            if hasattr(cur, "close"):
+                cur.close()
+    finally:
+        put_db(conn)
     # Notificación opcional aquí
     return {"id": slot["id"], "respuesta": "Cita reservada. Confirme para activar la reserva."}
 
@@ -268,16 +284,21 @@ def reserve_appointment(appt: AppointmentCreate):
 def confirm_appointment(body: AppointmentConfirm):
     """Confirmar una cita reservada"""
     conn = get_db()
-    cur = conn.cursor(cursor_factory=RealDictCursor)
-    cur.execute("SELECT * FROM appointments WHERE id=%s", (body.id,))
-    cita = cur.fetchone()
-    if not cita:
-        conn.close()
-        raise HTTPException(status_code=404, detail="Cita no encontrada")
-    # Confirmar
-    cur.execute("UPDATE appointments SET confirmada=TRUE WHERE id=%s", (body.id,))
-    conn.commit()
-    conn.close()
+    try:
+        cur = conn.cursor(cursor_factory=RealDictCursor)
+        try:
+            cur.execute("SELECT * FROM appointments WHERE id=%s", (body.id,))
+            cita = cur.fetchone()
+            if not cita:
+                raise HTTPException(status_code=404, detail="Cita no encontrada")
+            # Confirmar
+            cur.execute("UPDATE appointments SET confirmada=TRUE WHERE id=%s", (body.id,))
+            conn.commit()
+        finally:
+            if hasattr(cur, "close"):
+                cur.close()
+    finally:
+        put_db(conn)
     # Notificación al usuario y funcionario
     hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
     send_email(
@@ -295,22 +316,27 @@ def confirm_appointment(body: AppointmentConfirm):
 def cancel_appointment(body: AppointmentCancel):
     """Cancelar una cita reservada o confirmada"""
     conn = get_db()
-    cur = conn.cursor(cursor_factory=RealDictCursor)
-    cur.execute("SELECT * FROM appointments WHERE id=%s", (body.id,))
-    cita = cur.fetchone()
-    if not cita:
-        conn.close()
-        raise HTTPException(status_code=404, detail="Cita no encontrada")
-    # al cancelar, dejamos disponible=TRUE y confirmada=FALSE
-    cur.execute(
-        "UPDATE appointments "
-        "SET disponible = TRUE, confirmada = FALSE, "
-        "    motivo = '', usuario_nombre = '', usuario_email = '', usuario_whatsapp = '' "
-        "WHERE id = %s",
-        (body.id,)
-    )
-    conn.commit()
-    conn.close()
+    try:
+        cur = conn.cursor(cursor_factory=RealDictCursor)
+        try:
+            cur.execute("SELECT * FROM appointments WHERE id=%s", (body.id,))
+            cita = cur.fetchone()
+            if not cita:
+                raise HTTPException(status_code=404, detail="Cita no encontrada")
+            # al cancelar, dejamos disponible=TRUE y confirmada=FALSE
+            cur.execute(
+                "UPDATE appointments "
+                "SET disponible = TRUE, confirmada = FALSE, "
+                "    motivo = '', usuario_nombre = '', usuario_email = '', usuario_whatsapp = '' "
+                "WHERE id = %s",
+                (body.id,),
+            )
+            conn.commit()
+        finally:
+            if hasattr(cur, "close"):
+                cur.close()
+    finally:
+        put_db(conn)
     # Notificar usuario
     hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
     if cita["usuario_email"]:
@@ -330,10 +356,16 @@ def cancel_appointment(body: AppointmentCancel):
 def get_appointment(id: str):
     """Consultar detalles de una cita"""
     conn = get_db()
-    cur = conn.cursor(cursor_factory=RealDictCursor)
-    cur.execute("SELECT * FROM appointments WHERE id=%s", (id,))
-    cita = cur.fetchone()
-    conn.close()
+    try:
+        cur = conn.cursor(cursor_factory=RealDictCursor)
+        try:
+            cur.execute("SELECT * FROM appointments WHERE id=%s", (id,))
+            cita = cur.fetchone()
+        finally:
+            if hasattr(cur, "close"):
+                cur.close()
+    finally:
+        put_db(conn)
     if not cita:
         raise HTTPException(status_code=404, detail="Cita no encontrada")
     return AppointmentOut(**cita).as_dict()
@@ -343,11 +375,17 @@ def health():
     """Endpoint de salud para healthcheck"""
     try:
         conn = get_db()
-        cur = conn.cursor()
-        cur.execute("SELECT 1")
-        cur.fetchone()
-        conn.close()
-        return {"status": "ok", "database": "connected"}
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+            finally:
+                if hasattr(cur, "close"):
+                    cur.close()
+            return {"status": "ok", "database": "connected"}
+        finally:
+            put_db(conn)
     except Exception as e:
         return {"status": "error", "database": "disconnected", "error": str(e)}
 

--- a/services/scheduler-mcp/db.py
+++ b/services/scheduler-mcp/db.py
@@ -1,6 +1,7 @@
 import os
 import psycopg2
 from psycopg2.pool import SimpleConnectionPool
+from contextlib import contextmanager
 
 DB_DSN = os.getenv(
     "DATABASE_URL",
@@ -18,6 +19,14 @@ if not TESTING:
 
     def put_db(conn):
         _pool.putconn(conn)
+
+    @contextmanager
+    def db_connection():
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            put_db(conn)
 else:
     class _Dummy:
         def cursor(self, *a, **k):
@@ -41,3 +50,11 @@ else:
 
     def put_db(conn):
         pass
+
+    @contextmanager
+    def db_connection():
+        conn = get_db()
+        try:
+            yield conn
+        finally:
+            put_db(conn)

--- a/services/scheduler-mcp/repository.py
+++ b/services/scheduler-mcp/repository.py
@@ -8,7 +8,7 @@ import logging
 import json
 
 from psycopg2.extras import RealDictCursor
-from db import get_db
+from db import get_db, put_db
 from utils.audit import audit_step
 
 
@@ -101,5 +101,4 @@ def get_available_blocks(
                 cur.close()
 
     finally:
-        if hasattr(conn, "close"):
-            conn.close()
+        put_db(conn)

--- a/services/scheduler-mcp/tasks.py
+++ b/services/scheduler-mcp/tasks.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import requests
 from psycopg2.extras import RealDictCursor
 
-from db import get_db
+from db import get_db, put_db
 from notifications import send_email
 
 META_PHONE_ID = os.getenv('META_PHONE_ID')
@@ -43,8 +43,10 @@ def send_whatsapp(cita):
 
 def send_reminder(dry: bool = False):
     conn = get_db()
-    citas = fetch_tomorrow_confirmed(conn)
-    conn.close()
+    try:
+        citas = fetch_tomorrow_confirmed(conn)
+    finally:
+        put_db(conn)
     count = 0
     for cita in citas:
         if not dry:


### PR DESCRIPTION
## Summary
- return DB connections to the pool instead of closing them
- add optional `db_connection` context manager
- use connection return in scheduler endpoints and tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6875572bd758832f965f5aab89b907a6