### PR TITLE
Implement sequential appointment flow

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -285,6 +285,7 @@ def confirm_appointment(body: AppointmentConfirm):
         "Cita confirmada",
         "email/confirm.html",
         usuario=cita["usuario_nombre"],
+        funcionario=cita["funcionario_nombre"],
         fecha_legible=str(cita["fecha"]),
         hora=hora_str,
     )

--- a/services/scheduler-mcp/templates/email/confirm.html
+++ b/services/scheduler-mcp/templates/email/confirm.html
@@ -1,3 +1,5 @@
 <p>Hola {{ usuario }},</p>
-<p>Tu cita ha sido confirmada para el {{ fecha_legible }} a las {{ hora }}.</p>
+<p>Tu cita con {{ funcionario }} ha sido confirmada para el {{ fecha_legible }} a las {{ hora }}.</p>
+<p>Dirección: Edificio Consistorial Coruscant. Nivel 1313.</p>
+<p>Recuerda presentarte puntualmente y llevar la documentación necesaria.</p>
 <p>Gracias por usar nuestros servicios.</p>


### PR DESCRIPTION
## Summary
- implement step-by-step appointment flow in orchestrator
- add phone validation helper
- expand email confirmation template with location and reminders
- include funcionario name when sending confirmation email

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and RuntimeError for test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68759662f588832f920506ade77460ab