### PR TITLE
Fix connection leaks in scheduler-mcp

### DIFF
--- a/services/scheduler-mcp/repository.py
+++ b/services/scheduler-mcp/repository.py
@@ -8,7 +8,7 @@ import logging
 import json
 
 from psycopg2.extras import RealDictCursor
-from db import get_db
+from db import get_conn
 from utils.audit import audit_step
 
 
@@ -41,10 +41,8 @@ def get_available_blocks(
     • Usa comparación con columnas TIME (`hora_inicio`, `hora_fin`).
     • Ordena por `hora_inicio` ascendente.
     """
-    conn = get_db()
-    try:
-        cur = conn.cursor(cursor_factory=RealDictCursor)
-        try:
+    with get_conn() as conn:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
             sql = """
                 SELECT *
                 FROM   appointments
@@ -96,10 +94,3 @@ def get_available_blocks(
                 )
                 return [row] if row else []
             return []
-        finally:
-            if hasattr(cur, "close"):
-                cur.close()
-
-    finally:
-        from db import put_db
-        put_db(conn)

--- a/services/scheduler-mcp/tasks.py
+++ b/services/scheduler-mcp/tasks.py
@@ -3,7 +3,7 @@ from typing import Iterable
 import requests
 from psycopg2.extras import RealDictCursor
 
-from db import get_db
+from db import get_conn
 from notifications import send_email
 
 META_PHONE_ID = os.getenv('META_PHONE_ID')
@@ -42,9 +42,8 @@ def send_whatsapp(cita):
 
 
 def send_reminder(dry: bool = False):
-    conn = get_db()
-    citas = fetch_tomorrow_confirmed(conn)
-    conn.close()
+    with get_conn() as conn:
+        citas = fetch_tomorrow_confirmed(conn)
     count = 0
     for cita in citas:
         if not dry:

--- a/services/scheduler-mcp/test/test_scheduler.py
+++ b/services/scheduler-mcp/test/test_scheduler.py
@@ -44,12 +44,26 @@ def test_tools_call_listar(monkeypatch):
                 def fetchall(self_inner):
                     return rows
 
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+
             return C()
 
         def close(self):
             pass
 
-    monkeypatch.setattr(scheduler_app, "get_db", lambda: Dummy())
+    from contextlib import contextmanager
+
+    @contextmanager
+    def dummy_conn():
+        yield Dummy()
+
+    monkeypatch.setattr(scheduler_app, "get_conn", dummy_conn)
+    import sys
+    monkeypatch.setattr(sys.modules["repository"], "get_conn", dummy_conn)
 
     payload = {
         "tool": "scheduler-listar_horas_disponibles",
@@ -79,12 +93,26 @@ def test_exact_match(monkeypatch):
                 def fetchone(self_inner):
                     return row
 
+                def __enter__(self_inner):
+                    return self_inner
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    pass
+
             return C()
 
         def close(self):
             pass
 
-    monkeypatch.setattr(scheduler_app, "get_db", lambda: Dummy())
+    from contextlib import contextmanager
+
+    @contextmanager
+    def dummy_conn():
+        yield Dummy()
+
+    monkeypatch.setattr(scheduler_app, "get_conn", dummy_conn)
+    import sys
+    monkeypatch.setattr(sys.modules["repository"], "get_conn", dummy_conn)
 
     bloque = scheduler_app.get_available_block(date(2025, 7, 17), time.fromisoformat("10:00"))
     assert bloque["id"] == "C0028"


### PR DESCRIPTION
## Summary
- ensure database connections are returned to the pool in scheduler-mcp
- add `get_conn` context manager
- update repository, app and tasks to use `get_conn`
- adjust tests for new context manager

## Testing
- `pytest services/scheduler-mcp/test/test_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68768311c4f8832f85ff4acd7b26c3f2