### PR TITLE
Fix scheduler slot selection

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1424,6 +1424,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         if opciones and 1 <= choice <= len(opciones):
             b = opciones[choice - 1]
             ctx["bloque_cita"] = {
+                "slot_id": b.get("id"),
                 "fecha": b["fecha"],
                 "hora": b["hora_inicio"][:5],
             }
@@ -1431,7 +1432,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
             context_manager.update_pending_field(sid, "nombre_cita")
             return {"answer": FIELD_QUESTIONS["nombre_cita"], "pending": True}
         elif opciones and choice == len(opciones) + 1:
-            excluidos = [b["bloque_id"] for b in opciones]
+            excluidos = [b.get("id") for b in opciones]
             nuevas = call_tool_microservice(
                 "scheduler-listar_horas_cercanas",
                 {
@@ -1610,7 +1611,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         telefono = validar_telefono_movil(user_text)
         if not telefono:
             return {"answer": FIELD_QUESTIONS["whatsapp_cita"], "pending": True}
-        ctx["usuario_whatsapp"] = telefono
+        ctx["whatsapp_cita"] = telefono
         save_session(sid, ctx)
         context_manager.update_pending_field(sid, "mail_cita")
         return {"answer": FIELD_QUESTIONS["mail_cita"], "pending": True}


### PR DESCRIPTION
## Summary
- store selected appointment slot id when confirming a scheduler option
- use proper key for whatsapp during appointment booking

## Testing
- `pytest tests/test_agenda_slots.py::test_agenda_slot_flow -q` *(fails: assertion error)*

------
https://chatgpt.com/codex/tasks/task_e_6876f64736d4832f929831c27c3ed4a5