### PR TITLE
Fix slot_id mapping during scheduler reservation

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1424,7 +1424,7 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
         if opciones and 1 <= choice <= len(opciones):
             b = opciones[choice - 1]
             ctx["bloque_cita"] = {
-                "slot_id": b.get("slot_id"),
+                "slot_id": b.get("slot_id") or b.get("id"),
                 "fecha": b["fecha"],
                 "hora": b["hora_inicio"][:5],
             }

--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -261,6 +261,8 @@ class AppointmentOut(AppointmentCreate):
         data = super().model_dump(by_alias=False)
         # reconstruye el string horario
         data['hora'] = f"{self.hora_inicio.strftime('%H:%M')}-{self.hora_fin.strftime('%H:%M')}"
+        # Compatibilidad: exponer slot_id además de id
+        data['slot_id'] = self.id
         return data
 
 class AppointmentConfirm(BaseModel):


### PR DESCRIPTION
## Summary
- return `slot_id` in scheduler-mcp appointment objects
- fallback to `id` when storing selected block in orchestrator

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.text')*

------
https://chatgpt.com/codex/tasks/task_e_6877d1dff670832f880b4fec5604b5e2