### PR TITLE
Update appointment reservation flow

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1634,6 +1634,10 @@ def _handle_scheduler_flow(sid: str, user_text: str, base_dt: datetime) -> dict:
             payload["usuario_whatsapp"] = ctx["whatsapp_cita"]
         if ctx.get("motiv_cita"):
             payload["motivo"] = ctx["motiv_cita"]
+        if ctx.get("rut_cita"):
+            payload["usuario_rut"] = ctx["rut_cita"]
+        if ctx.get("depto_cita"):
+            payload["departamento_codigo"] = ctx["depto_cita"]
         import logging
         logging.info(f"[SCHEDULER] Payload enviado a scheduler-reservar_hora: {payload}")
         tool_result = call_tool_microservice("scheduler-reservar_hora", payload)


### PR DESCRIPTION
## Summary
- send confirmation mail and persist optional fields right after email input
- store RUT and department in appointments
- automatically send confirmation when reserving via REST or tool endpoint
- adjust confirm flow test

## Testing
- `pytest tests/test_confirm_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68781c752d1c832fb10d0dbcf1b25f92