### PR TITLE
Fix scheduler time slicing of datetime objects

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -155,7 +155,11 @@ async def tools_call(payload: dict):
                 )
                 conn.commit()
 
-                hora_str = f"{slot['hora_inicio'][:5]}-{slot['hora_fin'][:5]}"
+                hi = slot["hora_inicio"]
+                hf = slot["hora_fin"]
+                hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+                hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+                hora_str = f"{hi_str}-{hf_str}"
                 send_email(
                     usuario_mail,
                     "Cita confirmada",
@@ -182,7 +186,11 @@ async def tools_call(payload: dict):
                     raise HTTPException(status_code=404, detail="Cita no encontrada")
                 cur.execute("UPDATE appointments SET confirmada=TRUE WHERE id=%s", (reserva_id,))
                 conn.commit()
-        hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
+        hi = cita["hora_inicio"]
+        hf = cita["hora_fin"]
+        hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+        hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+        hora_str = f"{hi_str}-{hf_str}"
         send_email(
             cita["usuario_email"],
             "Cita confirmada",
@@ -214,7 +222,11 @@ async def tools_call(payload: dict):
                     (reserva_id,),
                 )
                 conn.commit()
-        hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
+        hi = cita["hora_inicio"]
+        hf = cita["hora_fin"]
+        hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+        hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+        hora_str = f"{hi_str}-{hf_str}"
         if cita["usuario_email"]:
             send_email(
                 cita["usuario_email"],
@@ -381,7 +393,11 @@ def reserve_appointment(appt: AppointmentCreate):
                 ),
             )
             conn.commit()
-            hora_str = f"{slot['hora_inicio'][:5]}-{slot['hora_fin'][:5]}"
+            hi = slot["hora_inicio"]
+            hf = slot["hora_fin"]
+            hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+            hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+            hora_str = f"{hi_str}-{hf_str}"
             send_email(
                 appt.usu_mail,
                 "Cita confirmada",
@@ -406,7 +422,11 @@ def confirm_appointment(body: AppointmentConfirm):
             cur.execute("UPDATE appointments SET confirmada=TRUE WHERE id=%s", (body.id,))
             conn.commit()
     # Notificación al usuario y funcionario
-    hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
+    hi = cita["hora_inicio"]
+    hf = cita["hora_fin"]
+    hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+    hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+    hora_str = f"{hi_str}-{hf_str}"
     send_email(
         cita["usuario_email"],
         "Cita confirmada",
@@ -438,7 +458,11 @@ def cancel_appointment(body: AppointmentCancel):
             )
             conn.commit()
     # Notificar usuario
-    hora_str = f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"
+    hi = cita["hora_inicio"]
+    hf = cita["hora_fin"]
+    hi_str = hi.strftime("%H:%M") if isinstance(hi, dtime) else str(hi)[:5]
+    hf_str = hf.strftime("%H:%M") if isinstance(hf, dtime) else str(hf)[:5]
+    hora_str = f"{hi_str}-{hf_str}"
     if cita["usuario_email"]:
         send_email(
             cita["usuario_email"],

--- a/services/scheduler-mcp/tasks.py
+++ b/services/scheduler-mcp/tasks.py
@@ -26,11 +26,15 @@ def send_whatsapp(cita):
     try:
         phone_number = cita['usuario_whatsapp'].replace('+', '')
         url = f"https://graph.facebook.com/v19.0/{META_PHONE_ID}/messages"
+        hi = cita["hora_inicio"]
+        hf = cita["hora_fin"]
+        hi_str = hi.strftime("%H:%M") if isinstance(hi, time) else str(hi)[:5]
+        hf_str = hf.strftime("%H:%M") if isinstance(hf, time) else str(hf)[:5]
         payload = {
             "messaging_product": "whatsapp",
             "to": phone_number,
             "type": "text",
-            "text": {"body": f"Recordatorio: Su cita es mañana {cita['fecha']} a las {f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}"} con {cita['funcionario_nombre']}."}
+            "text": {"body": f"Recordatorio: Su cita es mañana {cita['fecha']} a las {hi_str}-{hf_str} con {cita['funcionario_nombre']}."}
         }
         headers = {
             "Authorization": f"Bearer {META_TOKEN}",
@@ -47,13 +51,17 @@ def send_reminder(dry: bool = False):
     count = 0
     for cita in citas:
         if not dry:
+            hi = cita["hora_inicio"]
+            hf = cita["hora_fin"]
+            hi_str = hi.strftime("%H:%M") if isinstance(hi, time) else str(hi)[:5]
+            hf_str = hf.strftime("%H:%M") if isinstance(hf, time) else str(hf)[:5]
             send_email(
                 cita['usuario_email'],
                 'Recordatorio de cita municipal',
                 'email/reminder.html',
                 usuario=cita['usuario_nombre'],
                 fecha_legible=str(cita['fecha']),
-                hora=f"{cita['hora_inicio'][:5]}-{cita['hora_fin'][:5]}",
+                hora=f"{hi_str}-{hf_str}",
             )
             if cita.get('usuario_whatsapp'):
                 send_whatsapp(cita)

--- a/services/scheduler-mcp/test/test_scheduler.py
+++ b/services/scheduler-mcp/test/test_scheduler.py
@@ -120,4 +120,6 @@ def test_exact_match(monkeypatch):
     assert bloque["hora_fin"] == "10:30:00"
     # Verifica string horario reconstruido
     out = scheduler_app.AppointmentOut(**bloque).as_dict()
-    assert out["hora"] == f"{bloque['hora_inicio'][:5]}-{bloque['hora_fin'][:5]}"
+    hi_str = str(bloque['hora_inicio'])[:5]
+    hf_str = str(bloque['hora_fin'])[:5]
+    assert out["hora"] == f"{hi_str}-{hf_str}"


### PR DESCRIPTION
## Summary
- handle datetime objects when formatting scheduler hours
- adjust tests accordingly

## Testing
- `pytest services/scheduler-mcp/test/test_scheduler.py::test_exact_match -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.text')*

------
https://chatgpt.com/codex/tasks/task_e_687827e77438832f89ffe3dff0f2181f