### PR TITLE
Fix scheduler reserve endpoint return

### DIFF
--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -169,9 +169,6 @@ async def tools_call(payload: dict):
                     fecha_legible=str(slot["fecha"]),
                     hora=hora_str,
                 )
-                return {
-                    "respuesta": "Ya reservé tu cita. Recuerda que debes ser puntual y llegar antes de la hora estipulada. Debes llevar tu documentación actualizada y tus dudas bien estructuradas para que podamos ayudarte. Te esperamos."
-                }
         return {"id_reserva": slot_id, "estado": "pendiente", "mensaje": "Ya reservé tu cita. Recuerda que debes ser puntual y llegar antes de la hora estipulada. Debes llevar tu documentación actualizada y tus dudas bien estructuradas para que podamos ayudarte. Te esperamos."}
 
     if tool == "scheduler-confirmar_hora":


### PR DESCRIPTION
## Summary
- remove unreachable return in scheduler reservation tool
- keep consistent response after sending email

## Testing
- `pytest services/scheduler-mcp/test/test_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68785d1f8480832fa11dc90661511a33