### PR TITLE
Unify scheduler responses and configure SMTP vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,6 +162,10 @@ services:
       - ./services/scheduler-mcp/.env
     environment:
       - REDIS_HOST=redis
+      - SMTP_HOST=${SMTP_HOST}
+      - SMTP_PORT=${SMTP_PORT}
+      - SMTP_USER=${SMTP_USER}
+      - SMTP_PASS=${SMTP_PASS}
     ports:
       - "6001:6001"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- adjust scheduler-mcp API responses to return `id_reserva`, `estado` and `mensaje`
- set `confirmada` to `TRUE` when reserving slots
- expose SMTP variables in docker-compose so scheduler can send mail

## Testing
- `pytest services/scheduler-mcp/test -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.text')*

------
https://chatgpt.com/codex/tasks/task_e_6879045cfc50832f8ee3618375fd82a5