### PR TITLE
Fix SMTP port env parsing

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -18,9 +18,18 @@ import time
 import concurrent.futures
 from context_manager import ConversationalContextManager
 import unicodedata
-from utils.text import normalize_text
+try:
+    from utils.text import normalize_text
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'utils'))
+    from text import normalize_text
 from llama_client import LlamaClient
-from utils.parser import parse_date_time
+try:
+    from utils.parser import parse_date_time
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), ''))
+    import importlib
+    parse_date_time = importlib.import_module('utils.parser').parse_date_time
 import importlib.util
 service_path = '/app/scheduler-mcp/service.py'
 _spec = importlib.util.spec_from_file_location('scheduler_service', service_path)

--- a/services/scheduler-mcp/notifications.py
+++ b/services/scheduler-mcp/notifications.py
@@ -11,7 +11,11 @@ env = Environment(
 
 def send_email(to: str, subject: str, template: str, **ctx):
     SMTP_HOST = os.getenv('SMTP_HOST', 'smtp.sendgrid.net')
-    SMTP_PORT = int(os.getenv('SMTP_PORT', 587))
+    # If the environment variable is empty or invalid fallback to default 587
+    try:
+        SMTP_PORT = int(os.getenv('SMTP_PORT') or 587)
+    except ValueError:
+        SMTP_PORT = 587
     SMTP_USER = os.getenv('SMTP_USER', 'apikey')
     SMTP_PASS = os.getenv('SMTP_PASS', '')
     FROM = os.getenv('SENDER_EMAIL', SMTP_USER)


### PR DESCRIPTION
## Summary
- handle empty SMTP_PORT env var
- make orchestrator robust importing utils modules

## Testing
- `pytest services/scheduler-mcp/test/test_scheduler.py::test_health -q`
- `pytest services/scheduler-mcp/test/test_scheduler.py::test_list_available -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.parser')*

------
https://chatgpt.com/codex/tasks/task_e_68791a0644cc832f87a2854692dbff67