### PR TITLE
Remove local RAG flow

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -794,53 +794,6 @@ def detect_intent(
     return detect_intent_llm(user_input, history)
 
 
-def retrieve_context_snippets(pregunta: str, limit: int = 3) -> List[str]:
-    """Devuelve fragmentos relevantes de FAQ o documentos oficiales."""
-    snippets: List[str] = []
-
-    # 1) Buscar coincidencias en FAQ
-    try:
-        with open(FAQ_DB_PATH, "r", encoding="utf-8") as f:
-            faqs = json.load(f)
-        pregunta_tokens = set(tokenize(pregunta))
-        for entry in faqs:
-            entry_preguntas = entry["pregunta"]
-            if isinstance(entry_preguntas, str):
-                entry_preguntas = [entry_preguntas]
-            for alt in entry_preguntas:
-                entry_tokens = set(tokenize(normalize_text(alt)))
-                if pregunta_tokens & entry_tokens:
-                    snippets.append(entry["respuesta"].strip())
-                    break  # Solo una vez por entrada
-            if len(snippets) >= limit:
-                break
-    except Exception as e:
-        logging.warning(f"No se pudo consultar contexto FAQ: {e}")
-
-    # 2) Consultar documentos en la base de datos
-    try:
-        if len(snippets) < limit:
-            conn = get_db()
-            cur = conn.cursor(cursor_factory=RealDictCursor)
-            like = f"%{pregunta.lower()}%"
-            cur.execute(
-                "SELECT nombre, descripcion FROM documentos WHERE LOWER(nombre) LIKE %s OR LOWER(descripcion) LIKE %s LIMIT %s",
-                (like, like, limit - len(snippets)),
-            )
-            docs = cur.fetchall()
-            for doc in docs:
-                texto = doc.get("descripcion") or doc.get("nombre")
-                if texto:
-                    snippets.append(texto.strip())
-                    if len(snippets) >= limit:
-                        break
-            conn.close()
-    except Exception as e:
-        logging.warning(f"No se pudo consultar documentos: {e}")
-
-    return snippets[:limit]
-
-
 def get_best_faq_match(pregunta: str):
     """Devuelve la pregunta más parecida y su puntaje."""
     faqs = load_faq_cache()
@@ -2222,22 +2175,23 @@ def orchestrate(
             context_manager.clear_context_field(session_id, "doc_actual")
             return {"respuesta": answer, "session_id": session_id}
 
-        snippets = retrieve_context_snippets(user_input)
-        history = convo_ctx.get("history", [])
-        history_text = context_manager.get_history_as_string(history)
-        prompt_template = load_prompt("doc-generar_respuesta_llm.txt")
-        prompt = fill_prompt(
-            prompt_template,
-            {
-                "pregunta": user_input,
-                "language": "es",
-                "faq_context": "\n".join(snippets),
-            },
+        params = {"pregunta": user_input}
+        selected = context_manager.get_selected_document(session_id)
+        if selected:
+            params["documento"] = selected
+        service_resp = call_tool_microservice("doc-generar_respuesta_llm", params)
+        ans = (
+            service_resp.get("respuesta")
+            or service_resp.get("answer")
+            or service_resp.get("mensaje")
         )
-        prompt = f"{history_text}\n{prompt}"
-        ans = generate_response(prompt)
-        ans += "\n¿Te fue útil mi respuesta? (Sí/No)"
-        context_manager.set_feedback_pending(session_id, None)
+        if not ans:
+            ans = service_resp.get(
+                "error", "Lo siento, hubo un error al consultar el servicio."
+            )
+        else:
+            ans += "\n¿Te fue útil mi respuesta? (Sí/No)"
+            context_manager.set_feedback_pending(session_id, None)
         context_manager.update_context(session_id, user_input, ans)
         context_manager.clear_context_field(session_id, "doc_actual")
         return {"respuesta": ans, "session_id": session_id}

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -17,6 +17,35 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules["llama_cpp"] = fake_llama
 
+# Stub sklearn modules used in gateway
+fake_sklearn = types.ModuleType("sklearn")
+fake_feature = types.ModuleType("sklearn.feature_extraction")
+fake_text = types.ModuleType("sklearn.feature_extraction.text")
+class FakeVectorizer:
+    def fit(self, *a, **k):
+        return self
+    def fit_transform(self, *a, **k):
+        return [[0]]
+    def transform(self, *a, **k):
+        return [[0]]
+class FakeTfidfVectorizer(FakeVectorizer):
+    pass
+fake_text.TfidfVectorizer = FakeTfidfVectorizer
+fake_feature.text = fake_text
+fake_sklearn.feature_extraction = fake_feature
+fake_metrics = types.ModuleType("sklearn.metrics")
+fake_pairwise = types.ModuleType("sklearn.metrics.pairwise")
+def fake_cosine_similarity(*a, **k):
+    return [[1.0]]
+fake_pairwise.cosine_similarity = fake_cosine_similarity
+fake_metrics.pairwise = fake_pairwise
+fake_sklearn.metrics = fake_metrics
+sys.modules.setdefault("sklearn", fake_sklearn)
+sys.modules["sklearn.feature_extraction"] = fake_feature
+sys.modules["sklearn.feature_extraction.text"] = fake_text
+sys.modules["sklearn.metrics"] = fake_metrics
+sys.modules["sklearn.metrics.pairwise"] = fake_pairwise
+
 from gateway import app
 
 class TestGateway(unittest.TestCase):

--- a/services/scheduler-mcp/test/test_scheduler.py
+++ b/services/scheduler-mcp/test/test_scheduler.py
@@ -9,6 +9,30 @@ from fastapi.testclient import TestClient
 
 base_dir = os.path.join("services", "scheduler-mcp")
 sys.path.insert(0, base_dir)
+
+# Load scheduler utils as 'utils'
+import importlib.util as _util
+utils_spec = _util.spec_from_file_location("utils", os.path.join(base_dir, "utils", "__init__.py"))
+utils_pkg = _util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils_pkg)
+import types as _types
+email_utils_mod = _types.ModuleType("utils.email_utils")
+def _dummy(*a, **k):
+    pass
+email_utils_mod.send_email = _dummy
+rut_utils_spec = _util.spec_from_file_location("utils.rut_utils", os.path.join(base_dir, "utils", "rut_utils.py"))
+rut_utils_mod = _util.module_from_spec(rut_utils_spec)
+rut_utils_spec.loader.exec_module(rut_utils_mod)
+audit_spec = _util.spec_from_file_location("utils.audit", os.path.join(base_dir, "utils", "audit.py"))
+audit_mod = _util.module_from_spec(audit_spec)
+audit_spec.loader.exec_module(audit_mod)
+utils_pkg.email_utils = email_utils_mod
+utils_pkg.rut_utils = rut_utils_mod
+utils_pkg.audit = audit_mod
+sys.modules["utils"] = utils_pkg
+sys.modules["utils.email_utils"] = email_utils_mod
+sys.modules["utils.rut_utils"] = rut_utils_mod
+sys.modules["utils.audit"] = audit_mod
 spec = importlib.util.spec_from_file_location("scheduler_app", os.path.join(base_dir, "app.py"))
 scheduler_app = importlib.util.module_from_spec(spec)
 sys.modules["scheduler_app"] = scheduler_app

--- a/tests/test_confirm_flow.py
+++ b/tests/test_confirm_flow.py
@@ -11,6 +11,30 @@ os.environ["TESTING"] = "1"
 base_dir = os.path.join("services", "scheduler-mcp")
 sys.path.insert(0, base_dir)
 
+# Load scheduler utils as 'utils'
+import importlib.util as _util
+utils_spec = _util.spec_from_file_location("utils", os.path.join(base_dir, "utils", "__init__.py"))
+utils_pkg = _util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils_pkg)
+import types as _types
+email_utils_mod = _types.ModuleType("utils.email_utils")
+def _dummy(*a, **k):
+    pass
+email_utils_mod.send_email = _dummy
+rut_utils_spec = _util.spec_from_file_location("utils.rut_utils", os.path.join(base_dir, "utils", "rut_utils.py"))
+rut_utils_mod = _util.module_from_spec(rut_utils_spec)
+rut_utils_spec.loader.exec_module(rut_utils_mod)
+audit_spec = _util.spec_from_file_location("utils.audit", os.path.join(base_dir, "utils", "audit.py"))
+audit_mod = _util.module_from_spec(audit_spec)
+audit_spec.loader.exec_module(audit_mod)
+utils_pkg.email_utils = email_utils_mod
+utils_pkg.rut_utils = rut_utils_mod
+utils_pkg.audit = audit_mod
+sys.modules["utils"] = utils_pkg
+sys.modules["utils.email_utils"] = email_utils_mod
+sys.modules["utils.rut_utils"] = rut_utils_mod
+sys.modules["utils.audit"] = audit_mod
+
 spec = importlib.util.spec_from_file_location("scheduler_mcp", os.path.join(base_dir, "app.py"))
 scheduler_mcp = importlib.util.module_from_spec(spec)
 sys.modules["scheduler_mcp"] = scheduler_mcp

--- a/tests/test_retrieve_context.py
+++ b/tests/test_retrieve_context.py
@@ -33,11 +33,6 @@ orchestrator.context_manager.redis_client = fake
 orchestrator.get_db = lambda: (_ for _ in ()).throw(Exception("db disabled"))
 
 
-def test_retrieve_context_snippets_from_faq():
-    snippets = orchestrator.retrieve_context_snippets('¿Dónde estás ubicado?')
-    assert any('No tengo oficina virtual' in s for s in snippets)
-
-
 def test_get_best_faq_match():
     alt, score, entry = orchestrator.get_best_faq_match('donde esta tu oficina?')
     alt_norm = orchestrator.normalize_text(alt)

--- a/tests/test_tools_call_reservar.py
+++ b/tests/test_tools_call_reservar.py
@@ -11,6 +11,30 @@ os.environ["TESTING"] = "1"
 base_dir = os.path.join("services", "scheduler-mcp")
 sys.path.insert(0, base_dir)
 
+# Load scheduler utils package explicitly as 'utils'
+import importlib.util as _util
+utils_spec = _util.spec_from_file_location("utils", os.path.join(base_dir, "utils", "__init__.py"))
+utils_pkg = _util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils_pkg)
+import types as _types
+email_utils_mod = _types.ModuleType("utils.email_utils")
+def _dummy(*a, **k):
+    pass
+email_utils_mod.send_email = _dummy
+rut_utils_spec = _util.spec_from_file_location("utils.rut_utils", os.path.join(base_dir, "utils", "rut_utils.py"))
+rut_utils_mod = _util.module_from_spec(rut_utils_spec)
+rut_utils_spec.loader.exec_module(rut_utils_mod)
+audit_spec = _util.spec_from_file_location("utils.audit", os.path.join(base_dir, "utils", "audit.py"))
+audit_mod = _util.module_from_spec(audit_spec)
+audit_spec.loader.exec_module(audit_mod)
+utils_pkg.email_utils = email_utils_mod
+utils_pkg.rut_utils = rut_utils_mod
+utils_pkg.audit = audit_mod
+sys.modules["utils"] = utils_pkg
+sys.modules["utils.email_utils"] = email_utils_mod
+sys.modules["utils.rut_utils"] = rut_utils_mod
+sys.modules["utils.audit"] = audit_mod
+
 spec = importlib.util.spec_from_file_location("scheduler_mcp", os.path.join(base_dir, "app.py"))
 scheduler_mcp = importlib.util.module_from_spec(spec)
 sys.modules["scheduler_mcp"] = scheduler_mcp


### PR DESCRIPTION
## Summary
- drop `retrieve_context_snippets` and local LLM prompt/response generation
- call llm_docs microservice instead when intent is unknown
- adjust unit tests after removal of fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_687efa2f52e8832f83a1cabaa8e3690c