### PR TITLE
Log microservice routing

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -370,6 +370,7 @@ def fill_prompt(prompt_template: str, context: Dict[str, Any]) -> str:
 
 def call_tool_microservice(tool: str, params: Dict[str, Any]) -> Dict[str, Any]:
     service_url = route_to_service(tool)
+    logger.info(f"intent={tool}, routing to {service_url}")
     payload = {"tool": tool, "params": params}
     try:
         resp = requests.post(service_url, json=payload, timeout=30)


### PR DESCRIPTION
## Summary
- log route info when calling microservice to help debug integration

## Testing
- `pytest -q` *(fails: email-validator not installed, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f97d0f6c0832f8babbcf7a0e9b4df