### PR TITLE
Implement RAG flow in llm_docs-mcp

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -12,6 +12,8 @@ from starlette.responses import JSONResponse
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from llama_client import LlamaClient
+from embeddings import embed
+from qdrant_utils import search_in_qdrant, filter_by_document
 
 # ==== Configuración ====
 DOCUMENTS_PATH = os.getenv("DOCUMENTS_PATH", "documents/")
@@ -127,6 +129,40 @@ def generate_response(prompt: str) -> str:
     """Genera una respuesta utilizando el modelo Llama local."""
     return llama.generate(prompt)
 
+
+def generar_respuesta_llm(params: dict) -> str:
+    """Flujo RAG: embedding, búsqueda en Qdrant y generación con Llama."""
+    pregunta = params.get("pregunta", "")
+    if not pregunta:
+        return ""
+
+    # 1) Obtener embedding de la pregunta
+    vector = embed([pregunta])[0]
+
+    # 2) Aplicar filtro por documento si corresponde
+    filtro = filter_by_document(params.get("documento"))
+
+    # 3) Buscar fragmentos relevantes en Qdrant
+    try:
+        hits = search_in_qdrant(vector, top_k=5, filtro=filtro)
+    except Exception as e:
+        logger.error(f"Qdrant search failed: {e}")
+        hits = []
+
+    # 4) Construir contexto a partir de los fragmentos recuperados
+    fragments = []
+    for h in hits:
+        payload = getattr(h, "payload", {}) or {}
+        texto = payload.get("texto") or payload.get("text")
+        if texto:
+            fragments.append(texto)
+
+    contexto = "\n".join(fragments)
+    prompt = f"Contexto:\n{contexto}\n\nPregunta: {pregunta}\nRespuesta:"
+
+    # 5) Generar respuesta con Llama
+    return generate_response(prompt)
+
 # ==== MCP Endpoints ====
 @app.get("/tools/list")
 def tools_list():
@@ -159,6 +195,10 @@ async def tools_call(request: Request, credentials: HTTPBasicCredentials = Depen
         respuesta = generate_response(pregunta)
         logger.info("Respuesta generada por Llama (tool directo MCP)")
         return respuesta  # Solo el texto
+    elif tool == "doc-generar_respuesta_llm":
+        respuesta = generar_respuesta_llm(params)
+        logger.info("Respuesta generada por Llama con RAG")
+        return respuesta
     else:
         raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
 

--- a/services/llm_docs-mcp/qdrant_utils.py
+++ b/services/llm_docs-mcp/qdrant_utils.py
@@ -1,0 +1,33 @@
+from qdrant_client import QdrantClient
+from qdrant_client.http import models as qdrant
+import os
+
+# Connection and collection configuration
+QDRANT_HOST = os.getenv("QDRANT_HOST", "qdrant")
+QDRANT_PORT = int(os.getenv("QDRANT_PORT", 6333))
+COLLECTION = os.getenv("QDRANT_COLLECTION", "munbot_docs")
+
+client = QdrantClient(host=QDRANT_HOST, port=QDRANT_PORT)
+
+
+def search_in_qdrant(vector, top_k=5, filtro=None):
+    """Search similar vectors in Qdrant and return hits."""
+    return client.search(
+        collection_name=COLLECTION,
+        query_vector=vector,
+        query_filter=filtro,
+        limit=top_k,
+        with_payload=True,
+    )
+
+
+def filter_by_document(doc_name: str):
+    """Return a qdrant filter for the given document name."""
+    if not doc_name:
+        return None
+    return qdrant.Filter(must=[
+        qdrant.FieldCondition(
+            key="doc",
+            match=qdrant.MatchValue(value=doc_name)
+        )
+    ])

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -46,6 +46,25 @@ sys.modules["sklearn.feature_extraction.text"] = fake_text
 sys.modules["sklearn.metrics"] = fake_metrics
 sys.modules["sklearn.metrics.pairwise"] = fake_pairwise
 
+# Stub embeddings and Qdrant utils
+fake_embeddings = types.ModuleType("embeddings")
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules["embeddings"] = fake_embeddings
+
+fake_qdrant = types.ModuleType("qdrant_utils")
+class FakeHit:
+    def __init__(self):
+        self.payload = {"texto": "fragmento"}
+def fake_search_in_qdrant(*a, **k):
+    return [FakeHit()]
+def fake_filter_by_document(doc_name):
+    return None
+fake_qdrant.search_in_qdrant = fake_search_in_qdrant
+fake_qdrant.filter_by_document = fake_filter_by_document
+sys.modules["qdrant_utils"] = fake_qdrant
+
 from gateway import app
 
 class TestGateway(unittest.TestCase):
@@ -67,6 +86,14 @@ class TestGateway(unittest.TestCase):
         response = self.client.post("/process", json=data, auth=("admin", "admin"))
         self.assertEqual(response.status_code, 200)
         self.assertIn("respuesta", response.json())
+
+    def test_doc_generar_respuesta_llm(self):
+        payload = {
+            "tool": "doc-generar_respuesta_llm",
+            "params": {"pregunta": "hola"}
+        }
+        response = self.client.post("/tools/call", json=payload, auth=("admin", "admin"))
+        self.assertEqual(response.status_code, 200)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- create `qdrant_utils` helper with simple search and filtering
- load embeddings and qdrant helpers in `gateway.py`
- implement `generar_respuesta_llm` RAG function
- handle `doc-generar_respuesta_llm` tool
- extend tests with stubs and new endpoint check

## Testing
- `pytest services/llm_docs-mcp/test_tools.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: utils.phone_utils)*

------
https://chatgpt.com/codex/tasks/task_e_687f9e15e814832fbdda7b5afe88d992