### PR TITLE
Improve doc answer prompt generation

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -127,7 +127,7 @@ llama = LlamaClient()
 
 def generate_response(prompt: str) -> str:
     """Genera una respuesta utilizando el modelo Llama local."""
-    return llama.generate(prompt)
+    return llama.generate(prompt, max_tokens=256, temperature=0.6, top_p=0.95)
 
 
 def generar_respuesta_llm(params: dict) -> str:
@@ -151,14 +151,24 @@ def generar_respuesta_llm(params: dict) -> str:
 
     # 4) Construir contexto a partir de los fragmentos recuperados
     fragments = []
-    for h in hits:
+    for idx, h in enumerate(hits, start=1):
         payload = getattr(h, "payload", {}) or {}
         texto = payload.get("texto") or payload.get("text")
+        fuente = payload.get("fuente") or payload.get("doc")
         if texto:
-            fragments.append(texto)
+            item = f"{idx}. {texto}"
+            if fuente:
+                item += f" (Fuente: {fuente})"
+            fragments.append(item)
 
     contexto = "\n".join(fragments)
-    prompt = f"Contexto:\n{contexto}\n\nPregunta: {pregunta}\nRespuesta:"
+    prompt = (
+        f"El usuario pregunt\u00f3: {pregunta}\n"
+        "A continuaci\u00f3n se te proporcionan partes de documentos y datos relevantes:\n"
+        f"{contexto}\n"
+        "Utiliza esta informaci\u00f3n para responder de forma concisa y en espa\u00f1ol a la pregunta del usuario. "
+        "Si corresponde, indica la fuente de donde proviene la informaci\u00f3n."
+    )
 
     # 5) Generar respuesta con Llama
     return generate_response(prompt)

--- a/services/llm_docs-mcp/llama_client.py
+++ b/services/llm_docs-mcp/llama_client.py
@@ -11,13 +11,21 @@ class LlamaClient:
         else:
             self.llm = Llama(model_path=self.model_path, n_ctx=self.n_ctx, n_threads=self.n_threads)
 
-    def generate(self, prompt: str, max_tokens: int = 256, temperature: float = 0.7) -> str:
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 256,
+        temperature: float = 0.7,
+        top_p: float = 0.95,
+    ) -> str:
+        """Generate text from the model using the provided prompt."""
         if self.llm is None:
             return ""
         output = self.llm(
             prompt,
             max_tokens=max_tokens,
             temperature=temperature,
+            top_p=top_p,
             stop=["</s>", "<|endoftext|>"]
         )
         return output["choices"][0]["text"].strip()


### PR DESCRIPTION
## Summary
- accept `top_p` in llama client and forward to Llama
- tune generation settings in `generate_response`
- include fragments and their sources when composing LLM prompt

## Testing
- `python -m pytest -q services/llm_docs-mcp/test_tools.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'chilean_rut')*

------
https://chatgpt.com/codex/tasks/task_e_687fa18fb0a0832fa9024e6056aaf8cf