### PR TITLE
Include references in responses

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1737,6 +1737,9 @@ def orchestrate(
             or service_resp.get("answer")
             or service_resp.get("mensaje")
         )
+        references = service_resp.get("referencias")
+        if references:
+            answer = f"{answer}\nFuente: {'; '.join(references)}"
         no_results = (
             answer is None
             or not str(answer).strip()
@@ -1764,7 +1767,10 @@ def orchestrate(
             context_manager.set_feedback_pending(session_id, None)
             context_manager.update_context(session_id, user_input, answer)
             context_manager.clear_context_field(session_id, "doc_actual")
-            return {"respuesta": answer, "session_id": session_id}
+            resp = {"respuesta": answer, "session_id": session_id}
+            if references:
+                resp["referencias"] = references
+            return resp
 
     if tool == "unknown":
         params = {"pregunta": user_input}
@@ -1777,6 +1783,9 @@ def orchestrate(
             or service_resp.get("answer")
             or service_resp.get("mensaje")
         )
+        references = service_resp.get("referencias")
+        if references:
+            ans = f"{ans}\nFuente: {'; '.join(references)}"
         no_results = (
             ans is None
             or not str(ans).strip()
@@ -1804,7 +1813,10 @@ def orchestrate(
             context_manager.set_feedback_pending(session_id, None)
             context_manager.update_context(session_id, user_input, ans)
             context_manager.clear_context_field(session_id, "doc_actual")
-            return {"respuesta": ans, "session_id": session_id}
+            resp = {"respuesta": ans, "session_id": session_id}
+            if references:
+                resp["referencias"] = references
+            return resp
 
 
 # === API REST ===

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -176,6 +176,8 @@ def generar_respuesta_llm(params: dict) -> dict:
 
     # 5) Generar respuesta con Llama
     respuesta = generate_response(prompt)
+    if referencias:
+        respuesta = f"{respuesta}\n\nFuentes: {'; '.join(referencias)}"
     return {"respuesta": respuesta, "referencias": referencias}
 
 # ==== MCP Endpoints ====


### PR DESCRIPTION
## Summary
- propagate references from RAG service in orchestrator
- append list of references to textual response in RAG gateway

## Testing
- `pytest -q` *(fails: test_agenda_slot_flow, test_audit_tracing, test_available_next_week, test_available_empty_range, test_document_responses, test_farewell_resets_context, test_orchestrator_prompts_date, test_tokenize_stopwords, test_tramites_menu_flow)*

------
https://chatgpt.com/codex/tasks/task_e_687fadbf17b8832f9597a548314175e0