### PR TITLE
Add direct doc response endpoint

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -219,13 +219,25 @@ async def tools_call(request: Request, credentials: HTTPBasicCredentials = Depen
     else:
         raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
 
+@app.post("/doc-generar_respuesta_llm")
+async def doc_generar_respuesta_llm_endpoint(params: dict, credentials: HTTPBasicCredentials = Depends(authenticate)):
+    """Endpoint directo que combina búsqueda y generación."""
+    return generar_respuesta_llm(params)
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
 
 @app.get("/endpoints")
 def list_endpoints():
-    return {"endpoints": ["/tools/list", "/tools/call", "/health", "/metrics", "/process"]}
+    return {"endpoints": [
+        "/tools/list",
+        "/tools/call",
+        "/doc-generar_respuesta_llm",
+        "/health",
+        "/metrics",
+        "/process",
+    ]}
 
 @app.get("/metrics")
 def metrics():

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -95,5 +95,11 @@ class TestGateway(unittest.TestCase):
         response = self.client.post("/tools/call", json=payload, auth=("admin", "admin"))
         self.assertEqual(response.status_code, 200)
 
+    def test_doc_generar_respuesta_llm_direct(self):
+        payload = {"pregunta": "hola"}
+        resp = self.client.post("/doc-generar_respuesta_llm", json=payload, auth=("admin", "admin"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("respuesta", resp.json())
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expose `/doc-generar_respuesta_llm` in `llm_docs-mcp` for unified document search and answer
- list the new endpoint in `/endpoints`
- test the new endpoint via `TestGateway`

## Testing
- `pytest services/llm_docs-mcp/test_tools.py::TestGateway::test_doc_generar_respuesta_llm_direct -q`
- `pytest -q` *(fails: 15 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687fb15430ec832fba50a420cf96e00a