### PR TITLE
Add RAG fragment search endpoints

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -12,8 +12,8 @@ from starlette.responses import JSONResponse
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from llama_client import LlamaClient
-from embeddings import embed
-from qdrant_utils import search_in_qdrant, filter_by_document
+
+from rag import generar_respuesta, obtener_fragmentos
 
 # ==== Configuración ====
 DOCUMENTS_PATH = os.getenv("DOCUMENTS_PATH", "documents/")
@@ -131,54 +131,11 @@ def generate_response(prompt: str) -> str:
 
 
 def generar_respuesta_llm(params: dict) -> dict:
-    """Flujo RAG: embedding, búsqueda en Qdrant y generación con Llama.
-
-    Devuelve tanto la respuesta generada como las referencias utilizadas."""
+    """Genera respuesta usando la lógica RAG centralizada."""
     pregunta = params.get("pregunta", "")
-    if not pregunta:
-        return {"respuesta": "", "referencias": []}
-
-    # 1) Obtener embedding de la pregunta
-    vector = embed([pregunta])[0]
-
-    # 2) Aplicar filtro por documento si corresponde
-    filtro = filter_by_document(params.get("documento"))
-
-    # 3) Buscar fragmentos relevantes en Qdrant
-    try:
-        hits = search_in_qdrant(vector, top_k=5, filtro=filtro)
-    except Exception as e:
-        logger.error(f"Qdrant search failed: {e}")
-        hits = []
-
-    # 4) Construir contexto a partir de los fragmentos recuperados
-    fragments = []
-    referencias = []
-    for idx, h in enumerate(hits, start=1):
-        payload = getattr(h, "payload", {}) or {}
-        texto = payload.get("texto") or payload.get("text")
-        fuente = payload.get("fuente") or payload.get("doc")
-        if texto:
-            item = f"{idx}. {texto}"
-            if fuente:
-                item += f" (Fuente: {fuente})"
-                referencias.append(fuente)
-            fragments.append(item)
-
-    contexto = "\n".join(fragments)
-    prompt = (
-        f"El usuario pregunt\u00f3: {pregunta}\n"
-        "A continuaci\u00f3n se te proporcionan partes de documentos y datos relevantes:\n"
-        f"{contexto}\n"
-        "Utiliza esta informaci\u00f3n para responder de forma concisa y en espa\u00f1ol a la pregunta del usuario. "
-        "Si corresponde, indica la fuente de donde proviene la informaci\u00f3n."
-    )
-
-    # 5) Generar respuesta con Llama
-    respuesta = generate_response(prompt)
-    if referencias:
-        respuesta = f"{respuesta}\n\nFuentes: {'; '.join(referencias)}"
-    return {"respuesta": respuesta, "referencias": referencias}
+    k = int(params.get("k", 3))
+    doc = params.get("documento")
+    return generar_respuesta(pregunta, k, doc)
 
 # ==== MCP Endpoints ====
 @app.get("/tools/list")
@@ -216,6 +173,11 @@ async def tools_call(request: Request, credentials: HTTPBasicCredentials = Depen
         respuesta = generar_respuesta_llm(params)
         logger.info("Respuesta generada por Llama con RAG")
         return respuesta
+    elif tool == "doc-buscar_fragmento_documento":
+        consulta = params.get("consulta", "")
+        k = int(params.get("k", 3))
+        frags = obtener_fragmentos(consulta, k)
+        return {"fragmentos": frags}
     else:
         raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
 
@@ -223,6 +185,13 @@ async def tools_call(request: Request, credentials: HTTPBasicCredentials = Depen
 async def doc_generar_respuesta_llm_endpoint(params: dict, credentials: HTTPBasicCredentials = Depends(authenticate)):
     """Endpoint directo que combina búsqueda y generación."""
     return generar_respuesta_llm(params)
+
+
+@app.post("/doc-buscar_fragmento_documento")
+async def doc_buscar_fragmento_documento_endpoint(params: dict, credentials: HTTPBasicCredentials = Depends(authenticate)):
+    consulta = params.get("consulta", "")
+    k = int(params.get("k", 3))
+    return {"fragmentos": obtener_fragmentos(consulta, k)}
 
 @app.get("/health")
 def health():
@@ -234,6 +203,7 @@ def list_endpoints():
         "/tools/list",
         "/tools/call",
         "/doc-generar_respuesta_llm",
+        "/doc-buscar_fragmento_documento",
         "/health",
         "/metrics",
         "/process",
@@ -251,7 +221,13 @@ def process(data: dict, credentials: HTTPBasicCredentials = Depends(authenticate
 def root():
     return {
         "status": "MunBoT LLM Docs MCP running",
-        "endpoints": ["/tools/list", "/tools/call", "/health"],
+        "endpoints": [
+            "/tools/list",
+            "/tools/call",
+            "/health",
+            "/doc-generar_respuesta_llm",
+            "/doc-buscar_fragmento_documento",
+        ],
         "version": "1.0.0"
     }
 

--- a/services/llm_docs-mcp/llama_runner.py
+++ b/services/llm_docs-mcp/llama_runner.py
@@ -1,0 +1,19 @@
+import os
+from llama_cpp import Llama
+
+
+class LlamaRunner:
+    def __init__(self, model_path: str | None = None, n_ctx: int = 4096, n_threads: int = 2):
+        self.model_path = model_path or os.getenv("LLAMA_MODEL_PATH", "models/Llama-3.2-3B-Instruct-Q6_K.gguf")
+        self.n_ctx = int(os.getenv("N_CTX", n_ctx))
+        self.n_threads = int(os.getenv("N_THREADS", n_threads))
+        if os.getenv("LLAMA_MOCK") == "1":
+            self.llm = None
+        else:
+            self.llm = Llama(model_path=self.model_path, n_ctx=self.n_ctx, n_threads=self.n_threads)
+
+    def generate(self, prompt: str, max_tokens: int = 256, temperature: float = 0.6, top_p: float = 0.95) -> str:
+        if self.llm is None:
+            return ""
+        out = self.llm(prompt, max_tokens=max_tokens, temperature=temperature, top_p=top_p, stop=["</s>", "<|endoftext|>"])
+        return out["choices"][0]["text"].strip()

--- a/services/llm_docs-mcp/qdrant_client.py
+++ b/services/llm_docs-mcp/qdrant_client.py
@@ -1,0 +1,18 @@
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
+
+client = QdrantClient(host="qdrant", port=6333)
+
+
+def buscar_fragmentos(embedding: list[float], top_k: int = 5, filtro_doc: str | None = None):
+    filtro = None
+    if filtro_doc:
+        filtro = Filter(must=[FieldCondition(key="doc", match=MatchValue(value=filtro_doc))])
+    resultados = client.search(
+        collection_name="munbot_docs",
+        query_vector=embedding,
+        limit=top_k,
+        with_payload=True,
+        query_filter=filtro,
+    )
+    return resultados

--- a/services/llm_docs-mcp/rag.py
+++ b/services/llm_docs-mcp/rag.py
@@ -1,0 +1,29 @@
+from embeddings import embed
+from qdrant_client import buscar_fragmentos
+from llama_runner import LlamaRunner
+
+
+llama = LlamaRunner()
+
+
+def obtener_fragmentos(consulta: str, k: int = 3, documento: str | None = None):
+    vec = embed([consulta])[0]
+    hits = buscar_fragmentos(vec, top_k=k, filtro_doc=documento)
+    resultados = []
+    for h in hits:
+        payload = getattr(h, "payload", {}) or {}
+        resultados.append({
+            "doc_id": payload.get("doc") or payload.get("fuente", ""),
+            "titulo": payload.get("titulo") or payload.get("doc") or "",
+            "parrafo": payload.get("texto") or payload.get("text") or "",
+            "puntaje": getattr(h, "score", 0.0),
+        })
+    return resultados
+
+
+def generar_respuesta(pregunta: str, k: int = 3, documento: str | None = None):
+    fragmentos = obtener_fragmentos(pregunta, k, documento)
+    contexto = "\n".join(f["parrafo"] for f in fragmentos)
+    prompt = f"{contexto}\n\nPregunta: {pregunta}\nRespuesta:"
+    respuesta = llama.generate(prompt)
+    return {"respuesta": respuesta, "fragmentos": fragmentos}

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -65,6 +65,24 @@ fake_qdrant.search_in_qdrant = fake_search_in_qdrant
 fake_qdrant.filter_by_document = fake_filter_by_document
 sys.modules["qdrant_utils"] = fake_qdrant
 
+# Stub qdrant_client and llama_runner used by rag
+fake_qdrant_client = types.ModuleType("qdrant_client")
+class FakeHit2:
+    def __init__(self):
+        self.payload = {"doc": "doc.txt", "texto": "fragmento"}
+        self.score = 1.0
+def fake_buscar_fragmentos(*a, **k):
+    return [FakeHit2()]
+fake_qdrant_client.buscar_fragmentos = fake_buscar_fragmentos
+sys.modules["qdrant_client"] = fake_qdrant_client
+
+fake_llama_runner = types.ModuleType("llama_runner")
+class FakeRunner:
+    def generate(self, *a, **k):
+        return "ok"
+fake_llama_runner.LlamaRunner = lambda *a, **k: FakeRunner()
+sys.modules["llama_runner"] = fake_llama_runner
+
 from gateway import app
 
 class TestGateway(unittest.TestCase):
@@ -100,6 +118,17 @@ class TestGateway(unittest.TestCase):
         resp = self.client.post("/doc-generar_respuesta_llm", json=payload, auth=("admin", "admin"))
         self.assertEqual(resp.status_code, 200)
         self.assertIn("respuesta", resp.json())
+
+    def test_doc_buscar_fragmento_documento(self):
+        payload = {"consulta": "hola"}
+        resp = self.client.post("/doc-buscar_fragmento_documento", json=payload, auth=("admin", "admin"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("fragmentos", resp.json())
+
+    def test_doc_buscar_fragmento_documento_tool(self):
+        payload = {"tool": "doc-buscar_fragmento_documento", "params": {"consulta": "hola"}}
+        resp = self.client.post("/tools/call", json=payload, auth=("admin", "admin"))
+        self.assertEqual(resp.status_code, 200)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `qdrant_client` helper
- add simple `llama_runner` wrapper
- centralize rag logic in `rag.py`
- extend gateway with `/doc-buscar_fragmento_documento`
- update tests for new endpoints

## Testing
- `pytest services/llm_docs-mcp/test_tools.py tests/test_document_rag.py -q`
- `pytest -q` *(fails: test_agenda_slots, test_audit_flow, test_available_endpoint, test_farewell, test_parse_date_time_ignore, test_tokenize_stopwords, test_tramites_menu)*

------
https://chatgpt.com/codex/tasks/task_e_6880095f147c832f85db445e56e33378