### PR TITLE
Implement RAG helper functions and update gateway

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -13,7 +13,10 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from llama_client import LlamaClient
 
-from rag import generar_respuesta, obtener_fragmentos
+from rag import (
+    doc_buscar_fragmento_documento,
+    doc_generar_respuesta_llm,
+)
 
 # ==== Configuración ====
 DOCUMENTS_PATH = os.getenv("DOCUMENTS_PATH", "documents/")
@@ -133,9 +136,9 @@ def generate_response(prompt: str) -> str:
 def generar_respuesta_llm(params: dict) -> dict:
     """Genera respuesta usando la lógica RAG centralizada."""
     pregunta = params.get("pregunta", "")
-    k = int(params.get("k", 3))
-    doc = params.get("documento")
-    return generar_respuesta(pregunta, k, doc)
+    documento = params.get("documento")
+    respuesta = doc_generar_respuesta_llm(pregunta, documento)
+    return {"respuesta": respuesta}
 
 # ==== MCP Endpoints ====
 @app.get("/tools/list")
@@ -174,9 +177,9 @@ async def tools_call(request: Request, credentials: HTTPBasicCredentials = Depen
         logger.info("Respuesta generada por Llama con RAG")
         return respuesta
     elif tool == "doc-buscar_fragmento_documento":
-        consulta = params.get("consulta", "")
-        k = int(params.get("k", 3))
-        frags = obtener_fragmentos(consulta, k)
+        pregunta = params.get("pregunta") or params.get("consulta", "")
+        documento = params.get("documento")
+        frags = doc_buscar_fragmento_documento(pregunta, documento)
         return {"fragmentos": frags}
     else:
         raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
@@ -189,9 +192,9 @@ async def doc_generar_respuesta_llm_endpoint(params: dict, credentials: HTTPBasi
 
 @app.post("/doc-buscar_fragmento_documento")
 async def doc_buscar_fragmento_documento_endpoint(params: dict, credentials: HTTPBasicCredentials = Depends(authenticate)):
-    consulta = params.get("consulta", "")
-    k = int(params.get("k", 3))
-    return {"fragmentos": obtener_fragmentos(consulta, k)}
+    pregunta = params.get("pregunta") or params.get("consulta", "")
+    documento = params.get("documento")
+    return {"fragmentos": doc_buscar_fragmento_documento(pregunta, documento)}
 
 @app.get("/health")
 def health():

--- a/services/llm_docs-mcp/llama_runner.py
+++ b/services/llm_docs-mcp/llama_runner.py
@@ -2,6 +2,23 @@ import os
 from llama_cpp import Llama
 
 
+llm = Llama(
+    model_path=os.getenv("LLAMA_MODEL_PATH", "./models/Llama-3.2-3B-Instruct-Q6_K.gguf"),
+    n_ctx=int(os.getenv("N_CTX", 2048)),
+    n_threads=int(os.getenv("N_THREADS", 4)),
+)
+
+
+def generar_respuesta_llm(prompt: str) -> str:
+    resultado = llm(
+        prompt,
+        max_tokens=512,
+        temperature=0.7,
+        stop=["Usuario:", "Pregunta:"],
+    )
+    return resultado["choices"][0]["text"].strip()
+
+
 class LlamaRunner:
     def __init__(self, model_path: str | None = None, n_ctx: int = 4096, n_threads: int = 2):
         self.model_path = model_path or os.getenv("LLAMA_MODEL_PATH", "models/Llama-3.2-3B-Instruct-Q6_K.gguf")

--- a/services/llm_docs-mcp/rag.py
+++ b/services/llm_docs-mcp/rag.py
@@ -27,3 +27,27 @@ def generar_respuesta(pregunta: str, k: int = 3, documento: str | None = None):
     prompt = f"{contexto}\n\nPregunta: {pregunta}\nRespuesta:"
     respuesta = llama.generate(prompt)
     return {"respuesta": respuesta, "fragmentos": fragmentos}
+
+
+# === API simplificada utilizada por algunos servicios ===
+def doc_buscar_fragmento_documento(pregunta: str, documento: str | None = None):
+    """Devuelve una lista de fragmentos de texto para una pregunta dada."""
+    resultados = obtener_fragmentos(pregunta, 5, documento)
+    return [r["parrafo"] for r in resultados]
+
+
+def construir_prompt_con_fragmentos(pregunta: str, fragmentos: list[str]) -> str:
+    joined = "\n".join([f"- {frag}" for frag in fragmentos])
+    return (
+        "Responde a la siguiente pregunta usando la información dada.\n\n"
+        f"Pregunta: {pregunta}\n\n"
+        "Información relevante:\n"
+        f"{joined}\n\nRespuesta:"
+    )
+
+
+def doc_generar_respuesta_llm(pregunta: str, documento: str | None = None) -> str:
+    fragmentos = doc_buscar_fragmento_documento(pregunta, documento)
+    prompt = construir_prompt_con_fragmentos(pregunta, fragmentos)
+    respuesta = llama.generate(prompt)
+    return respuesta


### PR DESCRIPTION
## Summary
- create `doc_*` helper functions in `rag.py`
- add lightweight wrapper `generar_respuesta_llm` in `llama_runner.py`
- route RAG endpoints in `gateway.py` through new helpers

## Testing
- `pytest services/llm_docs-mcp/test_tools.py::TestGateway::test_endpoints -q`
- `pytest -q` *(fails: 9 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68800d004540832faf1e643789670894