### PR TITLE
Add document filter to RAG calls

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1520,6 +1520,8 @@ def orchestrate(
         selected = context_manager.get_selected_document(session_id)
         if selected:
             params["documento"] = selected
+            if len(user_input.split()) < 6:
+                params["pregunta"] = f"{user_input} del trámite {selected}"
         service_resp = call_tool_microservice(tool, params)
         answer = (
             service_resp.get("respuesta")
@@ -1566,6 +1568,8 @@ def orchestrate(
         selected = context_manager.get_selected_document(session_id)
         if selected:
             params["documento"] = selected
+            if len(user_input.split()) < 6:
+                params["pregunta"] = f"{user_input} del trámite {selected}"
         service_resp = call_tool_microservice("doc-generar_respuesta_llm", params)
         ans = (
             service_resp.get("respuesta")

--- a/tests/test_document_rag.py
+++ b/tests/test_document_rag.py
@@ -3,6 +3,7 @@ import os
 import sys
 import types
 import fakeredis
+import uuid
 
 os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
 
@@ -51,3 +52,15 @@ def test_followup_session(monkeypatch):
     orchestrator.orchestrate('y el horario?', session_id=sid)
     assert calls[0]['pregunta'] == 'informacion permiso de aterrizaje'
     assert len(calls) >= 1
+
+def test_short_question_expands(monkeypatch):
+    calls = []
+    def fake_call(tool, params):
+        calls.append(params.copy())
+        return {'respuesta': 'ok'}
+    monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
+    sid = str(uuid.uuid4())
+    orchestrator.context_manager.set_selected_document(sid, 'Permiso de Circulacion')
+    orchestrator.orchestrate('y el costo?', session_id=sid)
+    assert calls[0]['documento'] == 'Permiso de Circulacion'
+    assert calls[0]['pregunta'].endswith('del trámite Permiso de Circulacion')


### PR DESCRIPTION
## Summary
- pass `selected_document` to `llm_docs-mcp` when available
- expand short queries with the active document name
- test question expansion logic

## Testing
- `pytest tests/test_document_rag.py -q`
- `pytest -q` *(fails: test_agenda_slot_flow, test_audit_tracing, test_available_next_week, test_available_empty_range, test_farewell_resets_context, test_orchestrator_prompts_date, test_tokenize_removes_common_words, test_tokenize_accented_stopwords)*

------
https://chatgpt.com/codex/tasks/task_e_68801c362bcc832f89a8952cf40329e3