### PR TITLE
Implement human escalation on negative feedback

### DIFF
--- a/docs/USER_FEEDBACK.md
+++ b/docs/USER_FEEDBACK.md
@@ -19,3 +19,5 @@ Este documento describe brevemente las tablas incorporadas para almacenar pregun
 - **usuario_id**: identificador opcional del usuario.
 
 Estas tablas permiten analizar con mayor detalle en qué temas falla el bot y recopilar comentarios directos de los usuarios para mejorar continuamente el sistema.
+
+Cuando el usuario responde **"No"** al preguntar si la información fue útil, se considera un feedback negativo y se incrementa el contador interno de _fallbacks_. Alcanzado el umbral de tres fallos acumulados el orquestador derivará la conversación a un agente humano.

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -25,6 +25,11 @@ except ModuleNotFoundError:
     from text import normalize_text
 from llama_client import LlamaClient
 try:
+    from utils.human import registrar_evento_humano
+except Exception:  # pragma: no cover - allow tests to run without full package
+    def registrar_evento_humano(session_id: str, pregunta: str, trace_id: str | None = None) -> None:
+        pass
+try:
     from utils.parser import parse_date_time
 except ModuleNotFoundError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), ''))
@@ -1385,6 +1390,18 @@ def orchestrate(
         if re.fullmatch(r"(?i)(sí|si|yes|ok|okay|vale)", user_input.strip()):
             ack = "Gracias, me alegra que te haya ayudado."
         elif re.fullmatch(r"(?i)(no|n|nope)", user_input.strip()):
+            context_manager.increment_fallback_count(sid)
+            count = context_manager.get_fallback_count(sid)
+            logger.info(
+                f"Negative feedback. Fallback count increased to {count}",
+                extra={"trace_id": sid},
+            )
+            if count >= 3:
+                registrar_evento_humano(sid, user_input, trace_id=sid)
+                logger.info("Escalamiento a humano", extra={"trace_id": sid})
+                msg = "Lo siento, no puedo ayudarte... un experto te contactará."
+                context_manager.update_context(sid, user_input, msg)
+                return {"respuesta": msg, "session_id": sid, "escalado": True}
             ack = "Entiendo, seguiré mejorando. Gracias por tu feedback."
         else:
             ack = "Gracias por tu comentario."
@@ -1497,6 +1514,8 @@ def orchestrate(
         fallback_count = context_manager.get_fallback_count(session_id)
         if fallback_count >= 3 or sentiment == "very_negative":
             fallback_resp = "Lo siento, no puedo ayudarte en esto. Te pasaré con un agente humano."
+            registrar_evento_humano(session_id, user_input, trace_id=session_id)
+            logger.info("Escalamiento a humano", extra={"trace_id": session_id})
             context_manager.update_context(session_id, user_input, fallback_resp)
             return {"respuesta": fallback_resp, "session_id": session_id, "escalado": True}
         elif fallback_count == 2:
@@ -1542,6 +1561,8 @@ def orchestrate(
             fallback_count = context_manager.get_fallback_count(session_id)
             if fallback_count >= 3:
                 answer = "Lo siento, no puedo ayudarte en esto. Te pasaré con un agente humano."
+                registrar_evento_humano(session_id, user_input, trace_id=session_id)
+                logger.info("Escalamiento a humano", extra={"trace_id": session_id})
                 context_manager.update_context(session_id, user_input, answer)
                 return {"respuesta": answer, "session_id": session_id, "escalado": True}
             elif fallback_count == 2:
@@ -1590,6 +1611,8 @@ def orchestrate(
             fallback_count = context_manager.get_fallback_count(session_id)
             if fallback_count >= 3:
                 ans = "Lo siento, no puedo ayudarte en esto. Te pasaré con un agente humano."
+                registrar_evento_humano(session_id, user_input, trace_id=session_id)
+                logger.info("Escalamiento a humano", extra={"trace_id": session_id})
                 context_manager.update_context(session_id, user_input, ans)
                 return {"respuesta": ans, "session_id": session_id, "escalado": True}
             elif fallback_count == 2:

--- a/mcp-core/utils/human.py
+++ b/mcp-core/utils/human.py
@@ -1,0 +1,23 @@
+import os
+import json
+import logging
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+def registrar_evento_humano(session_id: str, pregunta: str, trace_id: str | None = None) -> None:
+    """Registra en un archivo de auditoría la derivación a un agente humano."""
+    registro = {
+        "session_id": session_id,
+        "pregunta": pregunta,
+        "timestamp": datetime.utcnow().isoformat(),
+        "trace_id": trace_id,
+    }
+    try:
+        path = os.getenv("HUMAN_ESCALATION_LOG", "human_escalations.log")
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(registro, ensure_ascii=False) + "\n")
+    except Exception as e:
+        logger.warning(f"No se pudo registrar evento humano: {e}")
+    logger.info(json.dumps(registro, ensure_ascii=False))

--- a/tests/test_human_escalation.py
+++ b/tests/test_human_escalation.py
@@ -1,0 +1,53 @@
+import importlib.util
+import os
+import sys
+import types
+import fakeredis
+from fastapi.testclient import TestClient
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+os.environ["PROMPTS_PATH"] = os.path.join('mcp-core', 'prompts')
+
+# Mock llama_cpp before importing orchestrator
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *args, **kwargs):
+        pass
+    def __call__(self, *args, **kwargs):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+orchestrator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(orchestrator)
+os.environ.pop("PROMPTS_PATH", None)
+
+fake = fakeredis.FakeRedis()
+orchestrator.redis_client = fake
+orchestrator.context_manager.redis_client = fake
+
+client = TestClient(orchestrator.app)
+
+
+def test_negative_feedback_escalates(monkeypatch):
+    sid = 'hum1'
+    orchestrator.context_manager.increment_fallback_count(sid)
+    orchestrator.context_manager.increment_fallback_count(sid)
+    orchestrator.context_manager.set_feedback_pending(sid, None)
+
+    captured = {}
+    def fake_registrar(sid_arg, pregunta, trace_id=None):
+        captured['sid'] = sid_arg
+        captured['pregunta'] = pregunta
+    monkeypatch.setattr(orchestrator, 'registrar_evento_humano', fake_registrar)
+
+    r = client.post('/orchestrate', json={'pregunta': 'No', 'session_id': sid})
+    assert r.status_code == 200
+    data = r.json()
+    assert 'experto te contactará' in data['respuesta'].lower()
+    assert data.get('escalado') is True
+    assert captured['sid'] == sid
+    assert orchestrator.context_manager.get_fallback_count(sid) >= 3


### PR DESCRIPTION
## Summary
- add `registrar_evento_humano` helper to log escalation events
- import helper in orchestrator with fallback stub
- bump fallback counter on negative feedback and escalate when threshold reached
- log and record human escalation when fallback threshold exceeded
- document fallback increase on negative feedback
- add regression test for negative feedback escalation

## Testing
- `pytest tests/test_human_escalation.py tests/test_feedback_pending.py -q`
- `pytest -q` *(fails: services/llm_docs-mcp/test_tools.py::TestGateway::test_doc_buscar_fragmento_documento etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68805023d924832fb0d4ff9b80f95722