### PR TITLE
Fix intent classifier to use local Llama model

### DIFF
--- a/mcp-core/utils/intent_classifier.py
+++ b/mcp-core/utils/intent_classifier.py
@@ -1,8 +1,4 @@
-import openai  # o tu cliente LLM preferido
-import os
-
-# Puedes usar dotenv si quieres cargar la clave desde .env
-openai.api_key = os.getenv("OPENAI_API_KEY")
+from llama_client import LlamaClient
 
 # Opcional: lista de intenciones válidas para validar retorno
 VALID_INTENTS = [
@@ -14,6 +10,8 @@ VALID_INTENTS = [
     "despedida",
     "otra"
 ]
+
+llm = LlamaClient()
 
 def classify_intent_with_llm(user_input: str) -> str:
     prompt = f"""
@@ -30,14 +28,8 @@ def classify_intent_with_llm(user_input: str) -> str:
 
     Responde solo con el código de la intención (por ejemplo: doc-generar_respuesta_llm).
     """
-
-    response = openai.ChatCompletion.create(
-        model="gpt-3.5-turbo",  # o el modelo LLM local
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0
-    )
-
-    intent = response.choices[0].message["content"].strip()
+    response_text = llm.generate(prompt, temperature=0)
+    intent = response_text.strip()
     if intent not in VALID_INTENTS:
         return "otra"
     return intent

--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -1,4 +1,6 @@
 import os
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import json
 import uuid
 import logging


### PR DESCRIPTION
## Summary
- remove OpenAI dependency in `intent_classifier`
- call local `LlamaClient` for intent classification
- allow scripts to import project modules by adjusting `sys.path`

## Testing
- `pytest -q` *(fails: assert False, others)*

------
https://chatgpt.com/codex/tasks/task_e_6881405956a4832fb8b2e615fb7be8cc