### PR TITLE
fix qdrant ids

### DIFF
--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -62,9 +62,15 @@ def load_rag_json_chunks(directory: str) -> list[dict]:
                         metadata["decreto"] = item["decreto"]
 
                     chunks.append({
-                        "id": item.get("id", str(uuid.uuid4())),
+                        # Qdrant solo acepta enteros o UUIDs como identificadores.
+                        # Para garantizar la compatibilidad, generamos siempre
+                        # un nuevo UUID y almacenamos el id original en el payload.
+                        "id": str(uuid.uuid4()),
                         "text": text_to_embed,
-                        "metadata": metadata,
+                        "metadata": {
+                            **metadata,
+                            "orig_id": item.get("id"),
+                        },
                     })
     return chunks
 


### PR DESCRIPTION
## Summary
- always assign a UUID to each document when indexing
- store the original doc id inside the metadata so Qdrant accepts the point id

## Testing
- `pytest -q` *(fails: 7 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881701377c0832fa5012d2e2c4de27e