### PR TITLE
Set HF_HOME for transformers cache

### DIFF
--- a/services/llm_docs-mcp/Dockerfile
+++ b/services/llm_docs-mcp/Dockerfile
@@ -4,7 +4,7 @@ ENV TZ=America/Santiago \
     TOKENIZERS_PARALLELISM=false \
     OMP_NUM_THREADS=4 \
     SENTENCE_TRANSFORMERS_HOME=/app/models \
-    TRANSFORMERS_CACHE=/app/models
+    HF_HOME=/app/models
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 


### PR DESCRIPTION
## Summary
- update llm_docs-mcp Dockerfile to use `HF_HOME` instead of deprecated `TRANSFORMERS_CACHE`

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'QdrantClient' & TypeError: Client.__init__ got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68818cbfc30c832f96599be8b718985a