### PR TITLE
Fix RAG fallback intents and improve scheduler debug

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -522,7 +522,10 @@ def detect_intent(text: str, testing: bool = False) -> str:
     try:
         if testing:
             return detect_intent_fallback(text)
-        return classify_intent_with_llm(text)
+        intent = classify_intent_with_llm(text)
+        if intent == "otra":
+            return detect_intent_fallback(text)
+        return intent
     except Exception as e:
         logger.warning(f"[INTENT] Fallback por error en LLM: {e}")
         return detect_intent_fallback(text)
@@ -1332,6 +1335,20 @@ def orchestrate(
             return {"respuesta": no_cancel_msg, "session_id": sid}
 
     # ----------- Inicio prioridad modo cita -----------
+    if os.getenv("AUDIT_SCHEDULER_DEBUG") == "true":
+        agenda = ctx.get("agenda", {})
+        if (
+            context_manager.get_current_flow(sid) == "scheduler"
+            or agenda.get("fecha")
+            or agenda.get("hora")
+            or re.search(
+                r"\b(?:agendar|reservar|cita|hora|turno)\b", user_input, re.IGNORECASE
+            )
+        ):
+            context_manager.set_current_flow(sid, "scheduler")
+            result = handle_agenda(user_input, sid)
+            return format_response(result, sid, trace_id=sid)
+
     if context_manager.get_current_flow(sid) == "scheduler":
         result = _handle_scheduler_flow(sid, user_input, datetime.now(tz=SANTIAGO_TZ))
         if result.get("pending") or result.get("finish"):
@@ -1431,7 +1448,12 @@ def orchestrate(
             re.IGNORECASE,
         ):
             context_manager.set_current_flow(sid, "scheduler")
-            result = _handle_scheduler_flow(sid, user_input, datetime.now(tz=SANTIAGO_TZ))
+            if os.getenv("AUDIT_SCHEDULER_DEBUG") == "true":
+                result = handle_agenda(user_input, sid)
+            else:
+                result = _handle_scheduler_flow(
+                    sid, user_input, datetime.now(tz=SANTIAGO_TZ)
+                )
             return format_response(result, sid, trace_id=sid)
         if kw_intent == "complaint-registrar_reclamo":
             context_manager.set_pending_confirmation(sid, True)
@@ -1608,7 +1630,7 @@ def orchestrate(
                 resp["referencias"] = references
             return resp
 
-    if tool == "unknown":
+    if tool in ["unknown", "informacion_general", "otra"]:
         params = {"pregunta": user_input}
         selected = context_manager.get_selected_document(session_id)
         if selected:

--- a/mcp-core/utils/audit.py
+++ b/mcp-core/utils/audit.py
@@ -5,20 +5,21 @@ import logging
 import inspect
 
 logger = logging.getLogger("audit")
-ENABLED = os.getenv("AUDIT_SCHEDULER_DEBUG", "false").lower() == "true"
 
 
 def audit_step(label):
     def wrapper(fn):
-        if not ENABLED:
-            return fn
-
         @functools.wraps(fn)
         def inner(*args, **kw):
+            if os.getenv("AUDIT_SCHEDULER_DEBUG", "false").lower() != "true":
+                return fn(*args, **kw)
+
             trace_id = kw.get("trace_id")
-            if trace_id is None and args:
-                trace_id = getattr(args[0], "sid", None)
             arg_names = inspect.getfullargspec(fn).args
+            if trace_id is None and "sid" in arg_names:
+                idx = arg_names.index("sid")
+                if idx < len(args):
+                    trace_id = args[idx]
             payload = {
                 "step": label,
                 "trace_id": trace_id,

--- a/services/scheduler-mcp/app.py
+++ b/services/scheduler-mcp/app.py
@@ -345,13 +345,16 @@ def list_available(request: Request):
         pattern = build_sql_pattern(hora_time)
         rows = get_available_blocks(date.fromisoformat(fecha), pattern)
     elif desde and hasta:
-        with get_conn() as conn:
-            with conn.cursor(cursor_factory=RealDictCursor) as cur:
-                cur.execute(
-                    "SELECT * FROM appointments WHERE fecha BETWEEN %s AND %s",
-                    (desde, hasta),
-                )
-                rows = cur.fetchall()
+        conn = get_db()
+        try:
+            cur = conn.cursor(cursor_factory=RealDictCursor)
+            cur.execute(
+                "SELECT * FROM appointments WHERE fecha BETWEEN %s AND %s",
+                (desde, hasta),
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
     else:
         return {"disponibles": []}
     out = []

--- a/services/scheduler-mcp/utils/audit.py
+++ b/services/scheduler-mcp/utils/audit.py
@@ -5,20 +5,21 @@ import logging
 import inspect
 
 logger = logging.getLogger("audit")
-ENABLED = os.getenv("AUDIT_SCHEDULER_DEBUG", "false").lower() == "true"
 
 
 def audit_step(label):
     def wrapper(fn):
-        if not ENABLED:
-            return fn
-
         @functools.wraps(fn)
         def inner(*args, **kw):
+            if os.getenv("AUDIT_SCHEDULER_DEBUG", "false").lower() != "true":
+                return fn(*args, **kw)
+
             trace_id = kw.get("trace_id")
-            if trace_id is None and args:
-                trace_id = getattr(args[0], "sid", None)
             arg_names = inspect.getfullargspec(fn).args
+            if trace_id is None and "sid" in arg_names:
+                idx = arg_names.index("sid")
+                if idx < len(args):
+                    trace_id = args[idx]
             payload = {
                 "step": label,
                 "trace_id": trace_id,


### PR DESCRIPTION
## Summary
- route `informacion_general` and `otra` intents through document answer flow
- honour `AUDIT_SCHEDULER_DEBUG` flag in the orchestrator
- use dynamic audit helpers so debug logs work when env vars are set after import
- allow scheduler's `/available` endpoint to use patched DB during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882632208d0832f95b2aa1d4f20541c