### PR TITLE
Improve service health check and retries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,8 @@ services:
       - munbot-net
     depends_on:
       - evolution-api
-      - mcp-core
+      mcp-core:
+        condition: service_healthy
 
   postgres:
     image: postgres:14
@@ -120,6 +121,12 @@ services:
       llm_docs-mcp:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   complaints-mcp:
     build: 

--- a/gateways/web-interface/socketServer.js
+++ b/gateways/web-interface/socketServer.js
@@ -28,6 +28,23 @@ const io = new Server(server, {
 });
 
 const MCP_URL = process.env.MCP_URL || 'http://mcp-core:5000/orchestrate'; // Nueva URL del MCP
+const MCP_TIMEOUT = parseInt(process.env.MCP_TIMEOUT || '5000', 10);
+
+async function postWithRetry(payload, attempts = 3, delay = 1000) {
+    let lastError;
+    for (let i = 0; i < attempts; i++) {
+        try {
+            return await axios.post(MCP_URL, payload, { timeout: MCP_TIMEOUT });
+        } catch (err) {
+            lastError = err;
+            if (i < attempts - 1) {
+                await new Promise(res => setTimeout(res, delay));
+                delay *= 2;
+            }
+        }
+    }
+    throw lastError;
+}
 
 io.on('connection', (socket) => {
     console.log('Un usuario se ha conectado');
@@ -45,8 +62,8 @@ io.on('connection', (socket) => {
                 session_id: socket.sessionId, // USAR sessionId del socket
                 channel: 'web'
             };
-            // Enviar el mensaje al MCP
-            const response = await axios.post(MCP_URL, payload);
+            // Enviar el mensaje al MCP con reintentos
+            const response = await postWithRetry(payload);
             // Actualizar el identificador de sesion si es devuelto por el MCP
             if (response.data) {
                 socket.sessionId = response.data.session_id || socket.sessionId;

--- a/mcp-core/README.md
+++ b/mcp-core/README.md
@@ -8,6 +8,7 @@ This directory contains the core logic for the Modular Conversational Platform (
   rarely helpful adverbs were removed to avoid filtering meaningful tokens.
 - `tool_schemas/`: JSON schemas describing each microservice's API as callable tools.
 - `prompts/`: Prompt templates for the LLM to guide tool usage and conversation flow.
+- A `/health` endpoint checks the database connection and that the LLM model is loaded.
 
 ## Next Steps
 - Implement the orchestrator logic in `orchestrator.py`.

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -183,6 +183,11 @@ ERROR_COUNTER = Counter(
 
 # --- Instancia tu LLM local (única instancia) ---
 llm = LlamaClient()
+try:
+    # Warm-up para compilar modelos antes de marcar el servicio listo
+    llm.generate("hola", max_tokens=1, temperature=0.0)
+except Exception:
+    pass
 
 NAME_REGEX = r"^[A-Za-zÁÉÍÓÚÜáéíóúüÑñ]+(?: [A-Za-zÁÉÍÓÚÜáéíóúüÑñ]+)+$"
 EMAIL_REGEX = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
@@ -1739,7 +1744,26 @@ def orchestrate_api(input: OrchestratorInput, request: Request):
 
 @app.get("/health")
 def health():
-    return {"status": "ok"}
+    db_ok = False
+    model_ok = False
+    try:
+        conn = get_db()
+        cur = conn.cursor()
+        cur.execute("SELECT 1")
+        cur.fetchone()
+        cur.close()
+        conn.close()
+        db_ok = True
+    except Exception:
+        db_ok = False
+    try:
+        # Verificamos que el modelo esté cargado
+        if getattr(llm, "llm", None) is not None:
+            model_ok = True
+    except Exception:
+        model_ok = False
+    status = "ok" if db_ok and model_ok else "error"
+    return {"status": status, "database": db_ok, "model": model_ok}
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- warm up the LLM on startup and expand `/health` to check DB and model status
- document new health endpoint
- configure mcp-core healthcheck and wait for healthy core in web interface
- add retry logic with timeout for messages from the web socket server

## Testing
- `pytest -q` *(fails: AssertionError: 403 != 200)*

------
https://chatgpt.com/codex/tasks/task_e_6882e87d662c832f8d6f443c60effa37