### PR TITLE
Fix Dockerfile apt packages

### DIFF
--- a/mcp-core/Dockerfile
+++ b/mcp-core/Dockerfile
@@ -10,9 +10,9 @@ RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     git \
-    libopenblas-base \
+    libopenblas0 \
     curl \
-    netcat \
+    netcat-openbsd \
   && rm -rf /var/lib/apt/lists/*
 
 # ───────────────────────────────


### PR DESCRIPTION
## Summary
- fix missing apt packages in mcp-core image

## Testing
- `pip install -r mcp-core/requirements.txt`
- `pytest -q` *(fails: 5 failed, 31 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6883d1918eac832fa0d81989e6a598ac