### PR TITLE
Fix Dockerfile entrypoint path

### DIFF
--- a/mcp-core/Dockerfile
+++ b/mcp-core/Dockerfile
@@ -37,7 +37,7 @@ COPY mcp-core/utils/ ./utils/
 COPY tests/ ./tests/
 
 RUN chmod +x wait-for-deps.sh
-ENTRYPOINT ["wait-for-deps.sh"]
+ENTRYPOINT ["./wait-for-deps.sh"]
 
 # ───────────────────────────────
 # 4) Variables de entorno y puertos


### PR DESCRIPTION
## Summary
- fix `ENTRYPOINT` path so Docker finds `wait-for-deps.sh`

## Testing
- `pytest -q` *(fails: test_doc_buscar_fragmento_documento, test_doc_buscar_fragmento_documento_tool, test_doc_generar_respuesta_llm, test_doc_generar_respuesta_llm_direct, test_process)*

------
https://chatgpt.com/codex/tasks/task_e_6883dae8b804832f8dbb0da48328cdd5