### PR TITLE
Unify Llama model usage

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -31,10 +31,10 @@ except ModuleNotFoundError:
     from text import normalize_text
 from llama_client import LlamaClient
 try:
-    from utils.intent_classifier import classify_intent_with_llm
+    from utils.intent_classifier import classify_intent_with_llm, set_llm_client
 except ModuleNotFoundError:
     sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'utils'))
-    from intent_classifier import classify_intent_with_llm
+    from intent_classifier import classify_intent_with_llm, set_llm_client
 try:
     from utils.human import registrar_evento_humano
 except Exception:  # pragma: no cover - allow tests to run without full package
@@ -188,6 +188,7 @@ try:
     llm.generate("hola", max_tokens=1, temperature=0.0)
 except Exception:
     pass
+set_llm_client(llm)
 
 NAME_REGEX = r"^[A-Za-zÁÉÍÓÚÜáéíóúüÑñ]+(?: [A-Za-zÁÉÍÓÚÜáéíóúüÑñ]+)+$"
 EMAIL_REGEX = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
@@ -534,7 +535,7 @@ def detect_intent(text: str, testing: bool = False) -> str:
     try:
         if testing:
             return detect_intent_fallback(text)
-        intent = classify_intent_with_llm(text)
+        intent = classify_intent_with_llm(text, llm)
         if intent == "otra":
             return detect_intent_fallback(text)
         return intent

--- a/mcp-core/utils/intent_classifier.py
+++ b/mcp-core/utils/intent_classifier.py
@@ -1,5 +1,21 @@
 from llama_client import LlamaClient
 
+_shared_llm: LlamaClient | None = None
+
+
+def set_llm_client(client: LlamaClient) -> None:
+    """Register a shared LlamaClient instance."""
+    global _shared_llm
+    _shared_llm = client
+
+
+def _get_llm() -> LlamaClient:
+    """Return the shared LlamaClient or create a new one lazily."""
+    global _shared_llm
+    if _shared_llm is None:
+        _shared_llm = LlamaClient()
+    return _shared_llm
+
 # Opcional: lista de intenciones válidas para validar retorno
 VALID_INTENTS = [
     "doc-generar_respuesta_llm",
@@ -11,9 +27,7 @@ VALID_INTENTS = [
     "otra"
 ]
 
-llm = LlamaClient()
-
-def classify_intent_with_llm(user_input: str) -> str:
+def classify_intent_with_llm(user_input: str, llm: LlamaClient | None = None) -> str:
     prompt = f"""
     El usuario dijo: \"{user_input}\".
     ¿Cuál es su intención principal?
@@ -28,7 +42,8 @@ def classify_intent_with_llm(user_input: str) -> str:
 
     Responde solo con el código de la intención (por ejemplo: doc-generar_respuesta_llm).
     """
-    response_text = llm.generate(prompt, temperature=0)
+    client = llm or _get_llm()
+    response_text = client.generate(prompt, temperature=0)
     intent = response_text.strip()
     if intent not in VALID_INTENTS:
         return "otra"


### PR DESCRIPTION
## Summary
- register a shared Llama client in `intent_classifier`
- use orchestrator's Llama instance for intent detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884050f75bc832faf4a473558ce79b1