### PR TITLE
Add audit logging utilities

### DIFF
--- a/mcp-core/src/orchestrator.py
+++ b/mcp-core/src/orchestrator.py
@@ -1,0 +1,41 @@
+import logging
+import time
+import requests
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+logger = logging.getLogger(__name__)
+
+DOC_SERVICE_HOST = "llm_docs_service"
+DOC_USER = "user"
+DOC_PASS = "pass"
+
+@app.route('/orchestrate', methods=['POST'])
+def orchestrate():
+    data = request.json
+    intent = data.get('tool')
+
+    logger.info(f"[AUDIT] Intento detectado: '{intent}' para pregunta: '{data.get('input', {}).get('pregunta')}'")
+    start_time = time.time()
+
+    try:
+        logger.info("[AUDIT] Llamando a llm_docs-mcp con herramienta doc-generar_respuesta_llm...")
+        resp = requests.post(
+            f"http://{DOC_SERVICE_HOST}:8000/tools/call",
+            auth=(DOC_USER, DOC_PASS),
+            json=data,
+            timeout=30
+        )
+        resp.raise_for_status()
+        result = resp.json()
+        logger.info(f"[AUDIT] Respuesta del microservicio recibida (primeros 100 chars): {result.get('respuesta', '')[:100]}...")
+
+    except Exception as e:
+        logger.exception("[AUDIT] Falló la llamada al microservicio de documentos")
+        return jsonify({"error": "Error interno al procesar la consulta."}), 500
+
+    finally:
+        elapsed = round(time.time() - start_time, 2)
+        logger.info(f"[AUDIT] Tiempo total orquestación: {elapsed}s")
+
+    return jsonify(result)

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -136,6 +136,12 @@ ERROR_COUNTER = Counter(
     ["intent"],
     registry=PROM_REGISTRY,
 )
+
+# === Métrica de latencia RAG para auditoría ===
+rag_latency = Histogram(
+    "rag_latency_seconds",
+    "Tiempo total de ejecución del flujo RAG (Qdrant -> Prompt -> LLM)"
+)
 RAG_LATENCY_HISTOGRAM = Histogram(
     "rag_latency_seconds",
     "Tiempo de latencia RAG",
@@ -205,6 +211,57 @@ llama = LlamaClient()
 def generate_response(prompt: str) -> str:
     """Genera una respuesta utilizando el modelo Llama local."""
     return llama.generate(prompt, max_tokens=256, temperature=0.6, top_p=0.95)
+
+
+# --- Nueva función de auditoría para RAG ---
+@rag_latency.time()
+async def generate_response_rag(pregunta: str, modelo) -> dict:
+    logger.info(f"[AUDIT] Pregunta recibida para RAG: '{pregunta}'")
+    start_time = time.time()
+
+    try:
+        # 1) Búsqueda en Qdrant
+        logger.info("[AUDIT] Realizando búsqueda en Qdrant...")
+        docs = vector_store.similarity_search(pregunta, top_k=5)
+        logger.info(f"[AUDIT] Qdrant devolvió {len(docs)} fragmentos: {[d.metadata['source'] for d in docs]}")
+
+        if not docs:
+            logger.warning("[AUDIT] No se encontraron documentos relevantes.")
+            elapsed = round(time.time() - start_time, 2)
+            logger.info(f"[AUDIT] Tiempo total sin docs: {elapsed}s")
+            return {
+                "respuesta": "No encontré información precisa...",
+                "referencias": [],
+                "no_results": True
+            }
+
+        # 2) Construcción del prompt
+        logger.info("[AUDIT] Construyendo prompt para el modelo...")
+        prompt = build_prompt(pregunta, docs)
+        logger.info(f"[AUDIT] Prompt generado (longitud {len(prompt)} chars): {prompt[:200]}...")
+
+        # 3) Llamada al modelo
+        logger.info("[AUDIT] Llamando al LLM para generar respuesta...")
+        respuesta = modelo.generate_response(
+            prompt,
+            max_tokens=150,
+            temperature=0.7,
+            stop=['</s>']
+        )
+        logger.info(f"[AUDIT] Respuesta generada ({len(respuesta.split())} tokens): {respuesta[:200]}...")
+
+        # 4) Métrica de duración
+        elapsed = round(time.time() - start_time, 2)
+        logger.info(f"[AUDIT] Tiempo total RAG: {elapsed}s")
+
+        return {
+            "respuesta": respuesta,
+            "referencias": [d.metadata['source'] for d in docs]
+        }
+
+    except Exception:
+        logger.exception("[AUDIT] Error inesperado durante el flujo RAG")
+        raise
 
 
 def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:


### PR DESCRIPTION
## Summary
- add `generate_response_rag` with detailed audit logs in gateway
- expose rag latency metric `rag_latency`
- provide example orchestrator with audit logs

## Testing
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688407ace018832fb18659b5aba0d190