### PR TITLE
Fix quantization loader

### DIFF
--- a/services/llm_docs-mcp/llama_client.py
+++ b/services/llm_docs-mcp/llama_client.py
@@ -31,7 +31,6 @@ class LlamaClient:
             self.model_path,
             trust_remote_code=True,
             device_map="auto",
-            load_in_4bit=True,
             quantization_config={"bits": 4},
         )
         self.generator = pipeline(

--- a/services/llm_docs-mcp/llama_runner.py
+++ b/services/llm_docs-mcp/llama_runner.py
@@ -15,7 +15,6 @@ if AutoTokenizer is not None and os.getenv("LLAMA_MOCK") != "1":
         _model_path,
         trust_remote_code=True,
         device_map="auto",
-        load_in_4bit=True,
         quantization_config={"bits": 4},
     )
     llm = pipeline(
@@ -54,7 +53,6 @@ class LlamaRunner:
             self.model_path,
             trust_remote_code=True,
             device_map="auto",
-            load_in_4bit=True,
             quantization_config={"bits": 4},
         )
         self.generator = pipeline(


### PR DESCRIPTION
## Summary
- remove `load_in_4bit` when `quantization_config` is used in llama client/runner

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils.phone_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6884f30bb92c832fa6e4f11ad2c6bb16