### PR TITLE
Update llm_docs-mcp env and compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
       # Período de gracia para que el contenedor complete su arranque (indexación, carga de modelos)
       start_period: 300s
     volumes:
-      - ./services/llm_docs-mcp/models:/app/services/llm_docs-mcp/models
+      - ./services/llm_docs-mcp/models:/models
 
   scheduler-mcp:
     build: 

--- a/services/llm_docs-mcp/.env
+++ b/services/llm_docs-mcp/.env
@@ -1,0 +1,14 @@
+# llm_docs-mcp environment configuration
+ALLOWED_IPS=127.0.0.1,192.168.1.100,172.18.0.0/16
+API_USERNAME=admin
+API_PASSWORD=supersecret
+LOG_PATH=/app/gateway.log
+DOCUMENTS_PATH=/documents/
+METADATA_PATH=/documents/metadata.json
+SIMILARITY_THRESHOLD=0.2
+QDRANT_SIMILARITY_THRESHOLD=0.3
+MODEL_PATH=/models/Llama-3.2-3B-Instruct-Q6_K.gguf
+N_THREADS=4
+N_CTX=4096
+LLAMA_N_THREADS=4
+HF_API_TOKEN=<YOUR_TOKEN_HERE>


### PR DESCRIPTION
## Summary
- add environment file for llm_docs-mcp with GGUF model path and context/thread settings
- update docker-compose volume path for llm_docs-mcp models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6886c2febb9c832fb7d1d0b9417c4532