### PR TITLE
Fix llm_docs-mcp Dockerfile heredoc

### DIFF
--- a/services/llm_docs-mcp/Dockerfile
+++ b/services/llm_docs-mcp/Dockerfile
@@ -25,6 +25,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Pre-descarga el modelo de embeddings para acelerar el arranque del contenedor
 RUN python - <<'PY'
+from sentence_transformers import SentenceTransformer
+SentenceTransformer(
+    "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
+    device="cpu",
+)
+PY
 
 # Copia código y scripts (una sola instrucción)
 COPY . .

--- a/services/llm_docs-mcp/requirements.txt
+++ b/services/llm_docs-mcp/requirements.txt
@@ -13,3 +13,4 @@ safetensors>=0.5.3
 sentence-transformers==2.7.0
 qdrant-client==1.7.0
 # torch se instala por separado en el Dockerfile.
+


### PR DESCRIPTION
## Summary
- close the Python heredoc in llm_docs-mcp Dockerfile and preload MiniLM
- clean requirements list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6886e0b335dc832fba8bc23d2296e990