### PR TITLE
Fix LLM health check URL

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1753,7 +1753,7 @@ def health():
     except Exception:
         db_ok = False
     try:
-        resp = requests.get(MICROSERVICES["llm_docs-mcp"].rstrip("/") + "/health", timeout=5)
+        resp = requests.get(LLM_DOCS_BASE.rstrip("/") + "/health", timeout=5)
         if resp.status_code == 200:
             model_ok = True
     except Exception:


### PR DESCRIPTION
## Summary
- call llm_docs-mcp health endpoint using base URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887917964a8832faec811e6ebece248