### PR TITLE
Remove Fuente label from orchestrator replies

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1614,8 +1614,6 @@ def orchestrate(
             or service_resp.get("mensaje")
         )
         references = service_resp.get("referencias")
-        if references:
-            answer = f"{answer}\nFuente: {'; '.join(references)}"
         logger.info(
             "Respuesta generada",
             extra={
@@ -1688,8 +1686,6 @@ def orchestrate(
             or service_resp.get("mensaje")
         )
         references = service_resp.get("referencias")
-        if references:
-            ans = f"{ans}\nFuente: {'; '.join(references)}"
         no_results = (
             ans is None
             or not str(ans).strip()


### PR DESCRIPTION
## Summary
- stop appending reference sources to text answers in `orchestrator.py`
- keep the `referencias` list for logging and responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889013161e4832f8b094e1ce0e6f643