### PR TITLE
Add generic document query clarification

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -208,6 +208,52 @@ FAREWELL_RESPONSE = (
     "inicia una nueva conversación."
 )
 
+# --- Detección de consultas genéricas sobre documentos ---
+DOC_MENTION_KEYWORDS = [
+    "certificado",
+    "documento",
+    "licencia",
+    "permiso",
+    "tramite",
+    "trámite",
+]
+
+DOC_FIELD_KEYWORDS = [
+    "requisito",
+    "requisitos",
+    "horario",
+    "direccion",
+    "dirección",
+    "donde",
+    "dónde",
+    "correo",
+    "mail",
+    "costo",
+    "valor",
+    "utilidad",
+]
+
+
+def extract_document_name(text: str) -> Optional[str]:
+    """Heurística simple para extraer el nombre de un documento."""
+    pattern = (
+        r"(?i)(certificado|licencia|permiso|documento|tr[áa]mite)"
+        r"(?: de| del)?\s+[A-Za-zÁÉÍÓÚÜáéíóúüñÑ ]+"
+    )
+    m = re.search(pattern, text)
+    if m:
+        return m.group(0).strip()
+    return None
+
+
+def is_generic_doc_query(text: str) -> bool:
+    """Determina si la consulta menciona un documento sin detallar campos."""
+    t = normalize_text(text)
+    mentions_doc = any(k in t for k in DOC_MENTION_KEYWORDS)
+    if not mentions_doc:
+        return False
+    return not any(k in t for k in DOC_FIELD_KEYWORDS)
+
 
 def extract_name_with_llm(user_text: str) -> Optional[str]:
     """Extrae un nombre completo de un texto, usando heurísticas y un LLM como fallback."""
@@ -1597,6 +1643,16 @@ def orchestrate(
             )
         params = {"pregunta": user_input}
         selected = context_manager.get_selected_document(session_id)
+
+        if is_generic_doc_query(user_input):
+            doc_name = selected or extract_document_name(user_input) or "el documento"
+            msg = (
+                f"¿Qué información específica deseas sobre {doc_name}? "
+                "Puedes consultar requisitos, dónde obtenerlo, horario, utilidad…"
+            )
+            context_manager.update_context(session_id, user_input, msg)
+            return {"respuesta": msg, "session_id": sid}
+
         if selected:
             params["documento"] = selected
             if len(user_input.split()) < 6:

--- a/tests/test_document_rag.py
+++ b/tests/test_document_rag.py
@@ -49,9 +49,11 @@ def test_followup_session(monkeypatch):
     monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
     r1 = orchestrator.orchestrate('informacion permiso de aterrizaje')
     sid = r1['session_id']
+    # primera consulta genérica no debe invocar el microservicio
+    assert calls == []
     orchestrator.orchestrate('y el horario?', session_id=sid)
-    assert calls[0]['pregunta'] == 'informacion permiso de aterrizaje'
-    assert len(calls) >= 1
+    assert len(calls) == 1
+    assert calls[0]['pregunta'] == 'y el horario?'
 
 def test_short_question_expands(monkeypatch):
     calls = []
@@ -64,3 +66,13 @@ def test_short_question_expands(monkeypatch):
     orchestrator.orchestrate('y el costo?', session_id=sid)
     assert calls[0]['documento'] == 'Permiso de Circulacion'
     assert calls[0]['pregunta'].endswith('del trámite Permiso de Circulacion')
+
+
+def test_generic_doc_query_prompts_specific(monkeypatch):
+    def fake_call(tool, params):
+        raise AssertionError('microservice should not be called')
+
+    monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
+    resp = orchestrator.orchestrate('licencia de conducir')
+    assert 'información específica' in resp['respuesta'].lower()
+    assert 'licencia de conducir' in resp['respuesta'].lower()


### PR DESCRIPTION
## Summary
- detect generic document questions with new `is_generic_doc_query`
- ask user for specific info instead of calling microservice
- test behaviour for generic document queries
- adjust follow-up session test for new logic

## Testing
- `pytest tests/test_document_rag.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: utils.email_utils)*

------
https://chatgpt.com/codex/tasks/task_e_688903fbf8a0832f9fa50f02dc8fbedc