### PR TITLE
Implement full doc summary flow

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -255,6 +255,46 @@ def is_generic_doc_query(text: str) -> bool:
     return not any(k in t for k in DOC_FIELD_KEYWORDS)
 
 
+def is_full_info_request(text: str) -> bool:
+    """Detecta si el usuario pide toda la información de un documento."""
+    t = normalize_text(text)
+    return "todo" in t or "completa" in t or "toda la informacion" in t
+
+
+def resumir_documento(nombre_doc: str) -> Optional[str]:
+    """Devuelve un resumen breve con distintos campos del documento."""
+    doc = buscar_documento_por_accion(nombre_doc)
+    if not doc:
+        return None
+    partes: List[str] = []
+    if doc.get("requisitos"):
+        partes.append("Requisitos: " + ", ".join(doc["requisitos"]))
+    oficinas = buscar_oficina_documento(doc["id_documento"])
+    if oficinas and oficinas.get("oficinas"):
+        of = oficinas["oficinas"][0]
+        detalles = []
+        if of.get("direccion"):
+            detalles.append(of["direccion"])
+        if of.get("horario"):
+            detalles.append(f"Horario: {of['horario']}")
+        if of.get("correo"):
+            detalles.append(f"Correo: {of['correo']}")
+        if detalles:
+            partes.append("Dónde tramitar: " + ", ".join(detalles))
+    labels = {
+        "utilidad": "Utilidad",
+        "tiempo_validez": "Vigencia",
+        "costo": "Costo",
+        "penalidad": "Penalidad",
+        "notas": "Notas",
+    }
+    for campo, label in labels.items():
+        info = buscar_info_documento_campo(doc["id_documento"], campo)
+        if info and info.get("valor"):
+            partes.append(f"{label}: {info['valor']}")
+    return "\n".join(partes) if partes else None
+
+
 def extract_name_with_llm(user_text: str) -> Optional[str]:
     """Extrae un nombre completo de un texto, usando heurísticas y un LLM como fallback."""
     cleaned_text = user_text.strip()
@@ -1645,10 +1685,16 @@ def orchestrate(
         selected = context_manager.get_selected_document(session_id)
 
         if is_generic_doc_query(user_input):
-            doc_name = selected or extract_document_name(user_input) or "el documento"
+            doc_name = selected or extract_document_name(user_input)
+            if doc_name and is_full_info_request(user_input):
+                summary = resumir_documento(doc_name)
+                if summary:
+                    context_manager.update_context(session_id, user_input, summary)
+                    return {"respuesta": summary, "session_id": sid}
+            doc_ref = doc_name or "el documento"
             msg = (
-                f"¿Qué información específica deseas sobre {doc_name}? "
-                "Puedes consultar requisitos, dónde obtenerlo, horario, utilidad…"
+                f"¿Qué información específica deseas sobre {doc_ref}? "
+                "Puedes consultar requisitos, dónde tramitarla, horarios, utilidad o vigencia."
             )
             context_manager.update_context(session_id, user_input, msg)
             return {"respuesta": msg, "session_id": sid}

--- a/tests/test_document_rag.py
+++ b/tests/test_document_rag.py
@@ -76,3 +76,27 @@ def test_generic_doc_query_prompts_specific(monkeypatch):
     resp = orchestrator.orchestrate('licencia de conducir')
     assert 'información específica' in resp['respuesta'].lower()
     assert 'licencia de conducir' in resp['respuesta'].lower()
+
+
+def test_full_info_summary(monkeypatch):
+    def fake_call(tool, params):
+        raise AssertionError('microservice should not be called')
+
+    monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
+
+    def fake_buscar_doc(acc):
+        return {'id_documento': 'LIC', 'nombre': 'Licencia de Conducir', 'requisitos': ['Foto']}
+
+    def fake_oficinas(doc_id):
+        return {'oficinas': [{'direccion': 'Av 1', 'horario': '8-12', 'correo': 'a@b.cl'}]}
+
+    def fake_info(doc_id, campo):
+        return None
+
+    monkeypatch.setattr(orchestrator, 'buscar_documento_por_accion', fake_buscar_doc)
+    monkeypatch.setattr(orchestrator, 'buscar_oficina_documento', fake_oficinas)
+    monkeypatch.setattr(orchestrator, 'buscar_info_documento_campo', fake_info)
+
+    resp = orchestrator.orchestrate('Quiero toda la información de la Licencia de Conducir')
+    assert 'requisitos' in resp['respuesta'].lower()
+    assert 'dónde tramitar' in resp['respuesta'].lower()


### PR DESCRIPTION
## Summary
- add helper functions to detect broad document info requests
- allow summarizing document details when user asks for all information
- test summary flow in document RAG behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688907ab7bf4832fa83bed2f04fb6f8d