### PR TITLE
Add semantic document routing

### DIFF
--- a/mcp-core/config/router_config.json
+++ b/mcp-core/config/router_config.json
@@ -1,0 +1,26 @@
+{
+  "RAG-Ayudas_Sociales.json": {
+    "description": "Información sobre beneficios, subsidios y ayudas económicas para ciudadanos vulnerables.",
+    "keywords": ["ayuda social", "beneficio", "subsidio", "vulnerabilidad"]
+  },
+  "RAG-Contrib_Derechos.json": {
+    "description": "Normativa y procesos relacionados con contribuciones e impuestos municipales.",
+    "keywords": ["contribuciones", "impuestos", "derechos", "cobro"]
+  },
+  "RAG-Horario_Comercio.json": {
+    "description": "Regulaciones sobre horarios de funcionamiento y cierre de locales comerciales.",
+    "keywords": ["horario comercio", "cierre de locales", "apertura", "locales"]
+  },
+  "RAG-Medio_Ambiente.json": {
+    "description": "Normativas sobre protección ambiental, reciclaje, calidad del aire y gestión de residuos.",
+    "keywords": ["medio ambiente", "reciclaje", "contaminación", "residuos"]
+  },
+  "RAG-Residencia.json": {
+    "description": "Información relacionada con residencia, inmigración y trámites de extranjería.",
+    "keywords": ["residencia", "inmigracion", "extranjería", "visa"]
+  },
+  "RAG.Seguridad.json": {
+    "description": "Decretos y manuales sobre seguridad ciudadana y defensa municipal.",
+    "keywords": ["seguridad", "defensa", "orden público", "protección"]
+  }
+}

--- a/mcp-core/document_router.py
+++ b/mcp-core/document_router.py
@@ -35,3 +35,37 @@ class DocumentRouter:
                 return self.topic_map[keyword]
         
         return None
+
+import os
+import sys
+import json
+import numpy as np
+from sklearn.metrics.pairwise import cosine_similarity
+
+# Permite importar 'embeddings' desde el microservicio de RAG
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp')))
+try:
+    from embeddings import embed
+except Exception:
+    # Durante pruebas el módulo puede ser stubbed
+    from importlib import import_module
+    embed = import_module('embeddings').embed
+
+class SemanticDocumentRouter:
+    """Enrutador de documentos basado en similitud semántica."""
+
+    def __init__(self, config_path: str):
+        with open(config_path, 'r', encoding='utf-8') as f:
+            self.config = json.load(f)
+        self.doc_names = list(self.config.keys())
+        descriptions = [d.get('description', '') for d in self.config.values()]
+        # Precalcular embeddings de las descripciones
+        self.description_vectors = embed(descriptions)
+
+    def get_document_topic(self, user_input: str, threshold: float = 0.75) -> Optional[str]:
+        vec = embed([user_input])[0]
+        sims = cosine_similarity([vec], self.description_vectors)[0]
+        best_idx = int(np.argmax(sims))
+        if sims[best_idx] >= threshold:
+            return self.doc_names[best_idx]
+        return None

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -25,7 +25,7 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
 )
 from faq_matcher import FAQMatcher
-from document_router import DocumentRouter
+from document_router import DocumentRouter, SemanticDocumentRouter
 try:
     from utils.text import normalize_text
 except ModuleNotFoundError:
@@ -122,6 +122,10 @@ DOCUMENT_TOPIC_MAP = {
     "defensa": "RAG.Seguridad.json"
 }
 document_router = DocumentRouter(DOCUMENT_TOPIC_MAP)
+
+# Configuración para el enrutador semántico
+ROUTER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config', 'router_config.json')
+semantic_router = SemanticDocumentRouter(ROUTER_CONFIG_PATH)
 
 # == Campos requeridos por tool ==
 REQUIRED_FIELDS = {
@@ -1442,7 +1446,9 @@ def orchestrate(
     # --- 0.5 (NUEVO) Enrutamiento por tema a documento específico ---
     # Si no es una FAQ, intentamos identificar si la consulta es sobre un tema conocido.
     # Esto es más rápido y preciso que depender siempre del LLM para la intención.
-    document_topic = document_router.get_document_topic(user_input)
+    document_topic = semantic_router.get_document_topic(user_input)
+    if not document_topic:
+        document_topic = document_router.get_document_topic(user_input)
     if document_topic:
         logger.info(f"Consulta enrutada al documento '{document_topic}' por tema.", extra={"trace_id": trace_id})
         # Guardamos el documento en el contexto para que el flujo RAG lo utilice.
@@ -1725,13 +1731,15 @@ def orchestrate(
             )
         history = context_manager.get_history(session_id)
         selected = context_manager.get_selected_document(session_id)
-                if summary:
-                    context_manager.update_context(session_id, user_input, summary)
-                    return {"respuesta": summary, "session_id": sid}
-            doc_ref = doc_name or "el documento"
+        params = {}
+
+        if is_generic_doc_query(user_input):
+            doc_name = selected or extract_document_name(user_input) or "el documento"
+            # FIX: Guardar el documento identificado en el contexto de la sesión
+            if doc_name and doc_name != "el documento":
                 context_manager.update_context_data(sid, {"selected_document": doc_name})
-                f"¿Qué información específica deseas sobre {doc_ref}? "
-                "Puedes consultar requisitos, dónde tramitarla, horarios, utilidad o vigencia."
+
+            msg = (
                 f"¿Qué información específica deseas sobre {doc_name}? "
                 "Puedes consultar requisitos, dónde obtenerlo, horario, utilidad…"
             )

--- a/tests/test_agenda_slots.py
+++ b/tests/test_agenda_slots.py
@@ -24,6 +24,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)

--- a/tests/test_audit_flow.py
+++ b/tests/test_audit_flow.py
@@ -23,6 +23,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 # import parser
 base_dir = os.path.abspath(os.path.join('services', 'scheduler-mcp'))
 sys.path.insert(0, os.path.abspath('mcp-core'))

--- a/tests/test_document_rag.py
+++ b/tests/test_document_rag.py
@@ -18,6 +18,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)

--- a/tests/test_farewell.py
+++ b/tests/test_farewell.py
@@ -19,6 +19,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))

--- a/tests/test_feedback_pending.py
+++ b/tests/test_feedback_pending.py
@@ -18,6 +18,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)

--- a/tests/test_human_escalation.py
+++ b/tests/test_human_escalation.py
@@ -19,6 +19,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)

--- a/tests/test_orchestrator_cancel.py
+++ b/tests/test_orchestrator_cancel.py
@@ -18,6 +18,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))

--- a/tests/test_parse_date_time_ignore.py
+++ b/tests/test_parse_date_time_ignore.py
@@ -18,6 +18,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 sys.path.insert(0, os.path.abspath('mcp-core'))
 spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)

--- a/tests/test_tokenize_stopwords.py
+++ b/tests/test_tokenize_stopwords.py
@@ -15,6 +15,13 @@ class FakeLlama:
 fake_llama.Llama = FakeLlama
 sys.modules['llama_cpp'] = fake_llama
 
+# Stub embeddings to avoid heavy model load
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
 os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
 sys.path.insert(0, os.path.abspath('mcp-core'))
 


### PR DESCRIPTION
## Summary
- allow semantic routing of documents with `SemanticDocumentRouter`
- store router descriptions in `router_config.json`
- instantiate router in orchestrator and fallback to keyword router
- stub `embeddings` in tests

## Testing
- `pytest tests/test_agenda_slots.py::test_agenda_slot_flow -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688939cf6ae0832fa50229407b09f53c