### PR TITLE
Add router for tramite documents

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -26,6 +26,7 @@ from prometheus_client import (
 )
 from faq_matcher import FAQMatcher
 from document_router import DocumentRouter, SemanticDocumentRouter
+from procedure_router import ProcedureRouter
 try:
     from utils.text import normalize_text
 except ModuleNotFoundError:
@@ -122,6 +123,20 @@ DOCUMENT_TOPIC_MAP = {
     "defensa": "RAG.Seguridad.json"
 }
 document_router = DocumentRouter(DOCUMENT_TOPIC_MAP)
+
+# == Configuración del Procedure Router ==
+PROCEDURE_FILE_PATH = os.getenv(
+    "PROCEDURES_FILE_PATH",
+    os.path.join(
+        os.path.dirname(__file__),
+        '..',
+        'services',
+        'llm_docs-mcp',
+        'documents',
+        'RAG-doc_tramites.json',
+    ),
+)
+procedure_router = ProcedureRouter(PROCEDURE_FILE_PATH)
 
 # Configuración para el enrutador semántico
 ROUTER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'config', 'router_config.json')
@@ -1443,6 +1458,15 @@ def orchestrate(
         # Las respuestas de FAQ no piden feedback para no interrumpir flujos simples.
         return {"respuesta": faq_response, "session_id": sid}
 
+    # --- 0.2 Enrutamiento por trámite específico ---
+    procedure_id = procedure_router.get_procedure_id(user_input)
+    if procedure_id:
+        logger.info(
+            f"Consulta enrutada al trámite ID '{procedure_id}' por alias.",
+            extra={"trace_id": trace_id},
+        )
+        context_manager.update_context_data(sid, {"selected_procedure_id": procedure_id})
+
     # --- 0.5 (NUEVO) Enrutamiento por tema a documento específico ---
     # Si no es una FAQ, intentamos identificar si la consulta es sobre un tema conocido.
     # Esto es más rápido y preciso que depender siempre del LLM para la intención.
@@ -1748,6 +1772,9 @@ def orchestrate(
 
         if selected:
             params["documento"] = selected
+        procedure_id_ctx = context_manager.get_context(sid).get("selected_procedure_id")
+        if procedure_id_ctx:
+            params["procedure_id"] = procedure_id_ctx
         params["pregunta"] = rewrite_query(history, user_input, selected)
         start_time = time.perf_counter()
         service_resp = call_tool_microservice("doc-generar_respuesta_llm", params)
@@ -1822,6 +1849,9 @@ def orchestrate(
         params = {"pregunta": rewrite_query(history, user_input, selected)}
         if selected:
             params["documento"] = selected
+        procedure_id_ctx = context_manager.get_context(sid).get("selected_procedure_id")
+        if procedure_id_ctx:
+            params["procedure_id"] = procedure_id_ctx
         service_resp = call_tool_microservice("doc-generar_respuesta_llm", params)
         err = handle_service_error(service_resp, "doc-generar_respuesta_llm", sid)
         if err:

--- a/mcp-core/procedure_router.py
+++ b/mcp-core/procedure_router.py
@@ -1,0 +1,46 @@
+import json
+import os
+from typing import Optional, Dict, List, Any
+
+try:
+    from utils.text import normalize_text
+except (ModuleNotFoundError, ImportError):
+    # Fallback for tests without package structure
+    def normalize_text(text: str) -> str:
+        import re
+        import unicodedata
+        text = text.lower()
+        text = ''.join(
+            c for c in unicodedata.normalize('NFD', text)
+            if unicodedata.category(c) != 'Mn'
+        )
+        text = re.sub(r'[^\w\s]', '', text)
+        return text
+
+
+class ProcedureRouter:
+    """Map user queries to a specific procedure ID based on alias matching."""
+
+    def __init__(self, procedures_path: str):
+        self.procedure_map: Dict[str, str] = {}
+        if not os.path.exists(procedures_path):
+            raise FileNotFoundError(f"Procedures file not found at: {procedures_path}")
+
+        with open(procedures_path, 'r', encoding='utf-8') as f:
+            procedures: List[Dict[str, Any]] = json.load(f)
+
+        for proc in procedures:
+            proc_id = proc.get("ID_Documento") or proc.get("id")
+            if not proc_id:
+                continue
+            for alias in proc.get("alias", []):
+                self.procedure_map[normalize_text(alias)] = proc_id
+
+        self.sorted_aliases = sorted(self.procedure_map.keys(), key=len, reverse=True)
+
+    def get_procedure_id(self, user_input: str) -> Optional[str]:
+        normalized_input = normalize_text(user_input)
+        for alias in self.sorted_aliases:
+            if alias in normalized_input:
+                return self.procedure_map[alias]
+        return None

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -23,7 +23,7 @@ from prometheus_client import (
 )
 from llama_client import LlamaClient
 from embeddings import embed
-from qdrant_utils import search_in_qdrant, filter_by_document
+from qdrant_utils import search_in_qdrant, filter_by_document, filter_by_procedure_id
 from rag import doc_buscar_fragmento_documento
 from intent_classifier import classify_intent_with_llm, set_llm_client
 
@@ -302,8 +302,14 @@ def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:
     logger.info("Generando embeddings", extra={"trace_id": trace_id})
     vector = embed([pregunta])[0]
 
-    # 2) Aplicar filtro por documento si corresponde
-    filtro = filter_by_document(params.get("documento"))
+    # 2) Aplicar filtro por documento o por ID de trámite
+    procedure_id = params.get("procedure_id")
+    document_name = params.get("documento")
+
+    if procedure_id:
+        filtro = filter_by_procedure_id(procedure_id)
+    else:
+        filtro = filter_by_document(document_name)
 
     # 3) Buscar fragmentos relevantes en Qdrant
     try:

--- a/services/llm_docs-mcp/qdrant_utils.py
+++ b/services/llm_docs-mcp/qdrant_utils.py
@@ -31,3 +31,15 @@ def filter_by_document(doc_name: str):
             match=qdrant.MatchValue(value=doc_name)
         )
     ])
+
+
+def filter_by_procedure_id(procedure_id: str | None):
+    """Return a qdrant filter for a specific procedure ID."""
+    if not procedure_id:
+        return None
+    return qdrant.Filter(must=[
+        qdrant.FieldCondition(
+            key="id_documento",
+            match=qdrant.MatchValue(value=procedure_id)
+        )
+    ])

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -63,6 +63,9 @@ def fake_filter_by_document(doc_name):
     return None
 fake_qdrant.search_in_qdrant = fake_search_in_qdrant
 fake_qdrant.filter_by_document = fake_filter_by_document
+def fake_filter_by_procedure_id(pid):
+    return None
+fake_qdrant.filter_by_procedure_id = fake_filter_by_procedure_id
 sys.modules["qdrant_utils"] = fake_qdrant
 
 # Stub qdrant_client and llama_runner used by rag


### PR DESCRIPTION
## Summary
- implement `ProcedureRouter` to map user queries to procedure IDs
- register procedure router in orchestrator and pass `procedure_id` to the RAG service
- use `procedure_id` in the llm_docs gateway and Qdrant utilities
- extend test utilities with stub for new filter

## Testing
- `pip install -r mcp-core/requirements.txt`
- `pip install -r services/llm_docs-mcp/requirements.txt`
- `pytest -q` *(fails: AssertionError in test_document_rag)*

------
https://chatgpt.com/codex/tasks/task_e_68893f7df36c832fb81566bdacdda6d2