### PR TITLE
Add department routing support

### DIFF
--- a/mcp-core/department_router.py
+++ b/mcp-core/department_router.py
@@ -1,0 +1,44 @@
+import json
+import os
+from typing import Optional, Dict, List, Any
+
+try:
+    from utils.text import normalize_text
+except (ModuleNotFoundError, ImportError):
+    def normalize_text(text: str) -> str:
+        import re
+        import unicodedata
+        text = text.lower()
+        text = ''.join(c for c in unicodedata.normalize('NFD', text) if unicodedata.category(c) != 'Mn')
+        text = re.sub(r'[\W_]+', ' ', text)
+        return text.strip()
+
+
+class DepartmentRouter:
+    """Identify a department ID from user input based on alias mapping."""
+
+    def __init__(self, departments_path: str) -> None:
+        self.department_map: Dict[str, str] = {}
+        if not os.path.exists(departments_path):
+            raise FileNotFoundError(f"Department file not found: {departments_path}")
+
+        with open(departments_path, "r", encoding="utf-8") as f:
+            departments: List[Dict[str, Any]] = json.load(f)
+
+        for dept in departments:
+            dept_id = dept.get("id")
+            if not dept_id:
+                continue
+            for alias in dept.get("alias", []):
+                self.department_map[normalize_text(alias)] = dept_id
+
+        # sort aliases by length (desc) to match longest first
+        self.sorted_aliases = sorted(self.department_map.keys(), key=len, reverse=True)
+
+    def get_department_id(self, text: str) -> Optional[str]:
+        """Return department ID if any alias is found in text."""
+        normalized = normalize_text(text)
+        for alias in self.sorted_aliases:
+            if alias in normalized:
+                return self.department_map[alias]
+        return None

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -27,6 +27,7 @@ from prometheus_client import (
 from faq_matcher import FAQMatcher
 from document_router import DocumentRouter
 from procedure_router import ProcedureRouter
+from department_router import DepartmentRouter
 try:
     from utils.text import normalize_text
 except ModuleNotFoundError:
@@ -110,6 +111,20 @@ faq_matcher = FAQMatcher(FAQ_FILE_PATH)
 # == Configuración del Procedure Router (Trámites) ==
 PROCEDURES_FILE_PATH = os.getenv("PROCEDURES_FILE_PATH", os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp', 'documents', 'Originales', 'documento_requisito.json'))
 procedure_router = ProcedureRouter(PROCEDURES_FILE_PATH)
+
+# == Configuración del Department Router (Departamentos) ==
+DEPARTMENTS_FILE_PATH = os.getenv(
+    "DEPARTMENTS_FILE_PATH",
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "services",
+        "llm_docs-mcp",
+        "documents",
+        "RAG-depto_info.json",
+    ),
+)
+department_router = DepartmentRouter(DEPARTMENTS_FILE_PATH)
 
 
 # == Configuración del Document Router ==
@@ -1451,6 +1466,15 @@ def orchestrate(
         # Guardamos el ID del trámite en el contexto para que el RAG lo utilice.
         context_manager.update_context_data(sid, {"selected_procedure_id": procedure_id})
 
+    # --- 0.3 (NUEVO) Enrutamiento por departamento específico ---
+    department_id = department_router.get_department_id(user_input)
+    if department_id:
+        logger.info(
+            f"Consulta enrutada al departamento ID '{department_id}' por alias.",
+            extra={"trace_id": trace_id},
+        )
+        context_manager.update_context_data(sid, {"selected_department_id": department_id})
+
 
     # --- 0.5 (NUEVO) Enrutamiento por tema a documento específico ---
     # Si no es una FAQ, intentamos identificar si la consulta es sobre un tema conocido.
@@ -1739,8 +1763,11 @@ def orchestrate(
         history = context_manager.get_history(session_id)
         selected = context_manager.get_selected_document(session_id)
         params = {}
-        if context_manager.get_context_data(session_id).get("selected_procedure_id"):
-            params["procedure_id"] = context_manager.get_context_data(session_id).get("selected_procedure_id")
+        ctx_data = context_manager.get_context(session_id)
+        if ctx_data.get("selected_procedure_id"):
+            params["procedure_id"] = ctx_data.get("selected_procedure_id")
+        if ctx_data.get("selected_department_id"):
+            params["department_id"] = ctx_data.get("selected_department_id")
 
         # FIX: Se corrige la lógica para que use el documento seleccionado por el router
         if is_generic_doc_query(user_input) and not selected:
@@ -1832,6 +1859,11 @@ def orchestrate(
         params = {"pregunta": rewrite_query(history, user_input, selected)}
         if selected:
             params["documento"] = selected
+        ctx_data = context_manager.get_context(session_id)
+        if ctx_data.get("selected_procedure_id"):
+            params["procedure_id"] = ctx_data.get("selected_procedure_id")
+        if ctx_data.get("selected_department_id"):
+            params["department_id"] = ctx_data.get("selected_department_id")
         service_resp = call_tool_microservice("doc-generar_respuesta_llm", params)
         err = handle_service_error(service_resp, "doc-generar_respuesta_llm", sid)
         if err:

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -23,7 +23,12 @@ from prometheus_client import (
 )
 from llama_client import LlamaClient
 from embeddings import embed
-from qdrant_utils import search_in_qdrant, filter_by_document, filter_by_procedure_id
+from qdrant_utils import (
+    search_in_qdrant,
+    filter_by_document,
+    filter_by_procedure_id,
+    filter_by_department_id,
+)
 from rag import doc_buscar_fragmento_documento
 from intent_classifier import classify_intent_with_llm, set_llm_client
 
@@ -302,12 +307,15 @@ def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:
     logger.info("Generando embeddings", extra={"trace_id": trace_id})
     vector = embed([pregunta])[0]
 
-    # 2) Aplicar filtro por documento o por ID de trámite
+    # 2) Aplicar filtro por ID de trámite, departamento o documento
     procedure_id = params.get("procedure_id")
+    department_id = params.get("department_id")
     document_name = params.get("documento")
 
     if procedure_id:
         filtro = filter_by_procedure_id(procedure_id)
+    elif department_id:
+        filtro = filter_by_department_id(department_id)
     else:
         filtro = filter_by_document(document_name)
 

--- a/services/llm_docs-mcp/qdrant_utils.py
+++ b/services/llm_docs-mcp/qdrant_utils.py
@@ -43,3 +43,15 @@ def filter_by_procedure_id(procedure_id: str | None):
             match=qdrant.MatchValue(value=procedure_id)
         )
     ])
+
+
+def filter_by_department_id(department_id: str | None):
+    """Return a qdrant filter for a specific department ID."""
+    if not department_id:
+        return None
+    return qdrant.Filter(must=[
+        qdrant.FieldCondition(
+            key="id",
+            match=qdrant.MatchValue(value=department_id)
+        )
+    ])

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -66,6 +66,9 @@ fake_qdrant.filter_by_document = fake_filter_by_document
 def fake_filter_by_procedure_id(pid):
     return None
 fake_qdrant.filter_by_procedure_id = fake_filter_by_procedure_id
+def fake_filter_by_department_id(did):
+    return None
+fake_qdrant.filter_by_department_id = fake_filter_by_department_id
 sys.modules["qdrant_utils"] = fake_qdrant
 
 # Stub qdrant_client and llama_runner used by rag

--- a/tests/test_department_router.py
+++ b/tests/test_department_router.py
@@ -1,0 +1,74 @@
+import importlib.util
+import os
+import sys
+import types
+import fakeredis
+
+os.environ["DISABLE_PERIODIC_MIGRATION"] = "1"
+
+# Mock llama_cpp before importing modules
+fake_llama = types.ModuleType('llama_cpp')
+class FakeLlama:
+    def __init__(self, *a, **k):
+        pass
+    def __call__(self, *a, **k):
+        return {"choices": [{"text": "ok"}]}
+
+fake_llama.Llama = FakeLlama
+sys.modules['llama_cpp'] = fake_llama
+
+# Stub embeddings
+fake_embeddings = types.ModuleType('embeddings')
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules['embeddings'] = fake_embeddings
+
+sys.path.insert(0, os.path.abspath('mcp-core'))
+
+# Import DepartmentRouter directly
+spec = importlib.util.spec_from_file_location('department_router', os.path.join('mcp-core', 'department_router.py'))
+department_router_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(department_router_mod)
+DepartmentRouter = department_router_mod.DepartmentRouter
+
+
+def test_department_router_alias():
+    path = os.path.join('services', 'llm_docs-mcp', 'documents', 'RAG-depto_info.json')
+    router = DepartmentRouter(path)
+    assert router.get_department_id('¿Cuál es el telefono de Coordinacion Regional?') == 'AI-001-contacto'
+
+# Test filter function
+spec_f = importlib.util.spec_from_file_location('qdrant_utils', os.path.join('services','llm_docs-mcp','qdrant_utils.py'))
+qdrant_utils = importlib.util.module_from_spec(spec_f)
+fake_qdrant = types.ModuleType('qdrant_client')
+class FakeClient:
+    def __init__(self, *a, **k):
+        pass
+fake_qdrant.QdrantClient = FakeClient
+class FakeFieldCondition:
+    def __init__(self, key=None, match=None):
+        self.key = key
+        self.match = match
+
+class FakeMatchValue:
+    def __init__(self, value=None):
+        self.value = value
+
+class FakeFilter(dict):
+    def __init__(self, must=None):
+        super().__init__()
+        self.must = must or []
+
+fake_models = types.SimpleNamespace(FieldCondition=FakeFieldCondition, MatchValue=FakeMatchValue, Filter=FakeFilter)
+fake_qdrant.http = types.SimpleNamespace(models=fake_models)
+fake_qdrant.__path__ = []
+sys.modules['qdrant_client'] = fake_qdrant
+sys.modules['qdrant_client.http'] = fake_qdrant.http
+spec_f.loader.exec_module(qdrant_utils)
+
+
+def test_filter_by_department_id():
+    filt = qdrant_utils.filter_by_department_id('D1')
+    assert filt.must[0].key == 'id'
+    assert filt.must[0].match.value == 'D1'


### PR DESCRIPTION
## Summary
- implement DepartmentRouter for mapping department aliases to IDs
- hook DepartmentRouter into orchestrator and pass department filter to microservice
- support department filter in RAG gateway and qdrant utilities
- update test stubs and add new tests for DepartmentRouter

## Testing
- `pytest tests/test_department_router.py -q`
- `pytest -q` *(fails: test_followup_session, test_full_info_summary)*

------
https://chatgpt.com/codex/tasks/task_e_688946d11294832fa4790c428193dfd1