### PR TITLE
Fix missing sklearn dependency

### DIFF
--- a/mcp-core/requirements.txt
+++ b/mcp-core/requirements.txt
@@ -11,3 +11,4 @@ chilean-rut
 phonenumbers
 prometheus_client>=0.16.0
 python-json-logger
+scikit-learn>=0.24.2


### PR DESCRIPTION
## Summary
- include `scikit-learn` in `mcp-core` requirements so that `DocumentRouter` works

## Testing
- `pytest -q` *(fails: 3 failed, 37 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688970094ec4832f849c441c3c31ebc9