### PR TITLE
Fix mcp-core missing sentence_transformers

### DIFF
--- a/mcp-core/requirements.txt
+++ b/mcp-core/requirements.txt
@@ -12,3 +12,5 @@ phonenumbers
 prometheus_client>=0.16.0
 python-json-logger
 scikit-learn>=0.24.2
+
+sentence-transformers==2.7.0


### PR DESCRIPTION
## Summary
- add `sentence-transformers` to mcp-core requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'chilean_rut')*

------
https://chatgpt.com/codex/tasks/task_e_68898522a840832f9c92986773803db7