### PR TITLE
feat: improve document routing and rag availability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
       - ./mcp-core/.env
     environment:
       - REDIS_HOST=redis
+      - DOCS_DIR=/app/documents
     ports:
       - "5000:5000"
     networks:
@@ -115,6 +116,7 @@ services:
       - ./mcp-core/models:/mcp-core/models
       - ./services/scheduler-mcp:/app/scheduler-mcp:ro
       - ./services/llm_docs-mcp:/services/llm_docs-mcp:ro
+      - ./services/llm_docs-mcp/documents:/app/documents:ro
     depends_on:
       redis:
         condition: service_healthy

--- a/mcp-core/config/router_config.json
+++ b/mcp-core/config/router_config.json
@@ -1,34 +1,29 @@
 {
-  "RAG-Ayudas_Sociales.json": {
-    "description": "Información sobre beneficios, subsidios y ayudas económicas para ciudadanos vulnerables.",
-    "keywords": ["ayuda social", "beneficio", "subsidio", "vulnerabilidad"]
-  },
-  "RAG-Contrib_Derechos.json": {
-    "description": "Normativa y procesos relacionados con contribuciones e impuestos municipales.",
-    "keywords": ["contribuciones", "impuestos", "derechos", "cobro"]
-  },
-  "RAG-Horario_Comercio.json": {
-    "description": "Regulaciones sobre horarios de funcionamiento y cierre de locales comerciales.",
-    "keywords": ["horario comercio", "cierre de locales", "apertura", "locales"]
-  },
-  "RAG-Medio_Ambiente.json": {
-    "description": "Normativas sobre protección ambiental, reciclaje, calidad del aire y gestión de residuos.",
-    "keywords": ["medio ambiente", "reciclaje", "contaminación", "residuos"]
-  },
-  "RAG-Residencia.json": {
-    "description": "Información relacionada con residencia, inmigración y trámites de extranjería.",
-    "keywords": ["residencia", "inmigracion", "extranjería", "visa"]
-  },
-  "RAG.Seguridad.json": {
-    "description": "Decretos y manuales sobre seguridad ciudadana y defensa municipal.",
-    "keywords": ["seguridad", "defensa", "orden público", "protección"]
-  },
-  "RAG-doc_tramites.json": {
-    "description": "Información sobre permisos, certificados, licencias, requisitos, horarios.",
-    "keywords": ["permiso", "certificado", "licencia", "requisito", "horario"]
-  },
-  "RAG-depto_info.json": {
-    "description": "Información sobre departamentos, contacto, correo, dirección, horario.",
-    "keywords": ["departamento", "contacto", "correo", "dirección", "horario"]
-  }
+  "documents": [
+    {
+      "name": "RAG-doc_tramites.json",
+      "description": "Trámites, permisos, licencias y certificados. Incluye requisitos, dónde obtener, horarios de atención, utilidad, penalidades y vigencias. Ejemplos: permiso de aterrizaje, licencia de piloto, patente comercial."
+    },
+    {
+      "name": "RAG-depto_info.json",
+      "description": "Directorio de departamentos: información de contacto, correo, dirección y horarios. Ejemplos: departamento de transporte interestelar, salud pública, seguridad pública."
+    },
+    {
+      "name": "RAG-Contrib_Derechos.json",
+      "description": "Contribuciones, derechos y tasas municipales: aseo domiciliario, alumbrado público, permisos y patentes."
+    },
+    {
+      "name": "RAG-Medio_Ambiente.json",
+      "description": "Reglamento ambiental: reciclaje, residuos, calidad del aire, protección de recursos hídricos."
+    },
+    {
+      "name": "RAG-Horario_Comercio.json",
+      "description": "Horarios de funcionamiento de comercios, ferias libres y cierres durante estados de excepción."
+    },
+    {
+      "name": "RAG-faq.json",
+      "description": "Preguntas frecuentes: saludos, despedidas, disponibilidad del bot, alcance de consultas."
+    }
+  ],
+  "semantic_threshold": 0.5
 }

--- a/mcp-core/document_router.py
+++ b/mcp-core/document_router.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 try:
     from utils.text import normalize_text
@@ -13,28 +13,22 @@ except (ModuleNotFoundError, ImportError):
         return text
 
 class DocumentRouter:
-    """
-    Identifica el documento o tema principal de una consulta de usuario
-    basándose en un mapa de palabras clave.
-    """
-    def __init__(self, topic_map: Dict[str, str]):
-        # Normalizamos las claves del mapa para una comparación robusta
-        self.topic_map = {normalize_text(k): v for k, v in topic_map.items()}
-        # Creamos una lista ordenada por longitud para evitar coincidencias parciales (ej: "patente" vs "patente de alcoholes")
-        self.sorted_keys = sorted(self.topic_map.keys(), key=len, reverse=True)
+    """Identifica el documento principal usando coincidencias por alias."""
+
+    def __init__(self, topic_map: Dict[str, List[str]]):
+        # Normalizamos alias para comparación robusta
+        self.topic_map = {
+            doc: [normalize_text(a) for a in aliases] for doc, aliases in topic_map.items()
+        }
 
     def get_document_topic(self, user_input: str) -> Optional[str]:
-        """
-        Busca una coincidencia de tema en la entrada del usuario.
-        Devuelve el nombre del documento asociado si lo encuentra.
-        """
         normalized_input = normalize_text(user_input)
-
-        for keyword in self.sorted_keys:
-            if keyword in normalized_input:
-                return self.topic_map[keyword]
-        
-        return None
+        best_doc, best_score = None, 0
+        for doc, aliases in self.topic_map.items():
+            score = sum(1 for alias in aliases if alias in normalized_input)
+            if score > best_score:
+                best_doc, best_score = doc, score
+        return best_doc if best_score > 0 else None
 
 import os
 import sys
@@ -55,17 +49,24 @@ class SemanticDocumentRouter:
     """Enrutador de documentos basado en similitud semántica."""
 
     def __init__(self, config_path: str):
-        with open(config_path, 'r', encoding='utf-8') as f:
-            self.config = json.load(f)
-        self.doc_names = list(self.config.keys())
-        descriptions = [d.get('description', '') for d in self.config.values()]
+        with open(config_path, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+        docs = raw.get("documents", [])
+        self.threshold = float(raw.get("semantic_threshold", 0.5))
+        self.doc_names = [d.get("name") for d in docs]
+        descriptions = [d.get("description", "") for d in docs]
         # Precalcular embeddings de las descripciones
         self.description_vectors = embed(descriptions)
 
-    def get_document_topic(self, user_input: str, threshold: float = 0.5) -> Optional[str]:
+    def route(self, user_input: str) -> tuple[Optional[str], float]:
         vec = embed([user_input])[0]
         sims = cosine_similarity([vec], self.description_vectors)[0]
         best_idx = int(np.argmax(sims))
-        if sims[best_idx] >= threshold:
-            return self.doc_names[best_idx]
+        return self.doc_names[best_idx], float(sims[best_idx])
+
+    def get_document_topic(self, user_input: str, threshold: Optional[float] = None) -> Optional[str]:
+        doc, score = self.route(user_input)
+        thr = threshold if threshold is not None else self.threshold
+        if doc and score >= thr:
+            return doc
         return None

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -21,7 +21,6 @@ import threading
 import time
 import concurrent.futures
 from context_manager import ConversationalContextManager
-from utils.query_rewriter import rewrite_query
 from prometheus_client import (
     Counter,
     CollectorRegistry,
@@ -29,7 +28,6 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
 )
 from department_router import DepartmentRouter
-from document_router import DocumentRouter
 from document_router import SemanticDocumentRouter
 try:
     from utils.human import registrar_evento_humano
@@ -145,36 +143,71 @@ DEPARTMENTS_FILE_PATH = os.getenv(
 )
 department_router = DepartmentRouter(DEPARTMENTS_FILE_PATH)
 
-def load_document_topics_from_files(docs_path: str) -> Dict[str, str]:
-    """Carga dinámicamente los alias de los documentos RAG para el enrutador."""
-    topic_map = {}
-    json_files = glob.glob(os.path.join(docs_path, "RAG-*.json"))
-    json_files += glob.glob(os.path.join(docs_path, "RAG.*.json"))
+DOCS_DIR = os.getenv(
+    "DOCS_DIR",
+    os.path.join(os.path.dirname(__file__), "..", "services", "llm_docs-mcp", "documents"),
+)
+
+
+def load_document_topics_from_files() -> Dict[str, list[str]]:
+    """Carga alias y tags de los documentos RAG para el enrutamiento."""
+    topic_map: Dict[str, set[str]] = {}
+    json_files = glob.glob(os.path.join(DOCS_DIR, "RAG-*.json"))
+    json_files += glob.glob(os.path.join(DOCS_DIR, "RAG.*.json"))
 
     for file_path in json_files:
         filename = os.path.basename(file_path)
+        aliases: set[str] = set()
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-                for item in data:
-                    for alias in item.get("alias", []):
-                        topic_map[alias] = filename
+                if isinstance(data, list):
+                    for item in data:
+                        for a in item.get("alias", []):
+                            aliases.add(a.lower())
+                        for t in item.get("tags", []):
+                            aliases.add(str(t).lower())
         except (json.JSONDecodeError, IOError) as e:
             logging.warning(f"Could not load or parse {filename}: {e}")
-    # Reglas adicionales específicas
-    topic_map.update({
-        "permiso aterrizaje": "RAG-doc_tramites.json",
-        "aterrizaje": "RAG-doc_tramites.json",
-    })
-    return topic_map
+        if aliases:
+            topic_map[filename] = sorted(aliases)
+    return {k: sorted(v) for k, v in topic_map.items()}
 
-DOCS_DIR_PATH = os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp', 'documents')
-DOCUMENT_TOPIC_MAP = load_document_topics_from_files(DOCS_DIR_PATH)
-document_router = DocumentRouter(DOCUMENT_TOPIC_MAP)
+
+DOCUMENT_TOPIC_MAP = load_document_topics_from_files()
 
 # Configuración para el enrutador semántico
 ROUTER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config", "router_config.json")
 semantic_router = SemanticDocumentRouter(ROUTER_CONFIG_PATH)
+
+SPECIFIC_RULES = [
+    (["permiso", "aterrizaje"], "RAG-doc_tramites.json"),
+]
+
+
+def apply_specific_rules(query: str) -> Optional[str]:
+    q = query.lower()
+    for tokens, target in SPECIFIC_RULES:
+        if all(t in q for t in tokens):
+            return target
+    return None
+
+
+def route_document(query: str) -> Optional[str]:
+    doc_sem, score = semantic_router.route(query)
+    thr = float(os.getenv("SEMANTIC_DOC_THRESHOLD", str(semantic_router.threshold)))
+    if doc_sem and score >= thr:
+        return doc_sem
+
+    q = query.lower()
+    best_doc, best_score = None, 0
+    for doc_name, aliases in DOCUMENT_TOPIC_MAP.items():
+        match_count = sum(1 for a in aliases if a in q)
+        if match_count > best_score:
+            best_doc, best_score = doc_name, match_count
+    if best_doc and best_score > 0:
+        return best_doc
+    return None
 
 # == Campos requeridos por tool ==
 REQUIRED_FIELDS = {
@@ -1509,10 +1542,7 @@ def orchestrate(
         context_manager.update_context_data(sid, {"selected_department_id": department_id})
     
     # --- 0.5 (NUEVO) Enrutamiento por tema a documento específico ---
-    # Primero intento semántico, si no, por palabra clave.
-    document_topic = semantic_router.get_document_topic(user_input, threshold=0.5)
-    if not document_topic:
-        document_topic = document_router.get_document_topic(user_input)
+    document_topic = apply_specific_rules(user_input) or route_document(user_input)
 
     if document_topic:
         logger.info(


### PR DESCRIPTION
## Summary
- ensure mcp-core has access to RAG JSON documents at runtime
- enrich semantic routing config and add keyword fallback with specific rules
- support new router config format in document router

## Testing
- `pytest` *(fails: TypeError: FakeFilter.__init__() got an unexpected keyword argument 'should')*


------
https://chatgpt.com/codex/tasks/task_e_689124d7accc832fbb12a46c543ea3c4