### PR TITLE
Fix semantic router with HTTP endpoint and fallback

### DIFF
--- a/mcp-core/config/router_config.json
+++ b/mcp-core/config/router_config.json
@@ -2,15 +2,15 @@
   "documents": [
     {
       "name": "RAG-doc_tramites.json",
-      "description": "Trámites, permisos, licencias y certificados. Incluye requisitos, dónde obtener, horarios de atención, utilidad, penalidades y vigencias. Ejemplos: permiso de aterrizaje, licencia de piloto, patente comercial."
+      "description": "Trámites, permisos, licencias y certificados: requisitos, dónde obtener, horarios, utilidad, penalidades y vigencia. Incluye 'permiso de aterrizaje', 'licencia de piloto', 'patente comercial'."
     },
     {
       "name": "RAG-depto_info.json",
-      "description": "Directorio de departamentos: información de contacto, correo, dirección y horarios. Ejemplos: departamento de transporte interestelar, salud pública, seguridad pública."
+      "description": "Directorio de departamentos: contacto, correo, dirección, horario. Incluye 'departamento de transporte interestelar', 'salud pública', 'seguridad pública'."
     },
     {
       "name": "RAG-Contrib_Derechos.json",
-      "description": "Contribuciones, derechos y tasas municipales: aseo domiciliario, alumbrado público, permisos y patentes."
+      "description": "Contribuciones y tasas municipales: aseo, alumbrado, patentes."
     },
     {
       "name": "RAG-Medio_Ambiente.json",

--- a/mcp-core/document_router.py
+++ b/mcp-core/document_router.py
@@ -8,7 +8,9 @@ except (ModuleNotFoundError, ImportError):
         import re
         import unicodedata
         text = text.lower()
-        text = ''.join(c for c in unicodedata.normalize('NFD', text) if unicodedata.category(c) != 'Mn')
+        text = ''.join(
+            c for c in unicodedata.normalize('NFD', text) if unicodedata.category(c) != 'Mn'
+        )
         text = re.sub(r'[^\w\s]', '', text)
         return text
 
@@ -31,40 +33,78 @@ class DocumentRouter:
         return best_doc if best_score > 0 else None
 
 import os
-import sys
 import json
+import logging
 import numpy as np
+import requests
 from sklearn.metrics.pairwise import cosine_similarity
 
-# Permite importar 'embeddings' desde el microservicio de RAG
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp')))
 try:
-    from embeddings import embed
+    from embeddings import embed as _embed
 except Exception:
-    # Durante pruebas el módulo puede ser stubbed
-    from importlib import import_module
-    embed = import_module('embeddings').embed
+    _embed = None
 
 class SemanticDocumentRouter:
     """Enrutador de documentos basado en similitud semántica."""
 
-    def __init__(self, config_path: str):
+    def __init__(self, config_path: str, remote_url: Optional[str] = None):
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.DEBUG)
         with open(config_path, "r", encoding="utf-8") as f:
             raw = json.load(f)
-        docs = raw.get("documents", [])
+        self.docs = raw.get("documents", [])
         self.threshold = float(raw.get("semantic_threshold", 0.5))
-        self.doc_names = [d.get("name") for d in docs]
-        descriptions = [d.get("description", "") for d in docs]
-        # Precalcular embeddings de las descripciones
-        self.description_vectors = embed(descriptions)
+        self.doc_names = [d.get("name") for d in self.docs]
+        self.remote_url = remote_url
+        if not self.remote_url:
+            if _embed is None:
+                raise ImportError("embeddings module not available")
+            descriptions = [d.get("description", "") for d in self.docs]
+            self.description_vectors = _embed(descriptions)
+            dim = len(self.description_vectors[0]) if self.description_vectors else 0
+            self.logger.debug(
+                "Router config loaded with %d documents (dim=%d)",
+                len(self.doc_names),
+                dim,
+            )
+        else:
+            self.description_vectors = None
+            self.logger.debug(
+                "Router config loaded with %d documents (remote=%s)",
+                len(self.doc_names),
+                self.remote_url,
+            )
 
     def route(self, user_input: str) -> tuple[Optional[str], float]:
-        vec = embed([user_input])[0]
+        if self.remote_url:
+            payload = {
+                "query": user_input,
+                "documents": self.docs,
+                "threshold": self.threshold,
+            }
+            try:
+                r = requests.post(
+                    f"{self.remote_url}/semantic-route", json=payload, timeout=30
+                )
+                r.raise_for_status()
+                data = r.json()
+                doc, score = data.get("name"), float(data.get("score", 0.0))
+            except Exception as e:
+                self.logger.warning("Remote routing failed: %s", e)
+                doc, score = None, 0.0
+            self.logger.debug("remote route query=%s doc=%s score=%.3f", user_input, doc, score)
+            return doc, score
+        vec = _embed([user_input])[0]
         sims = cosine_similarity([vec], self.description_vectors)[0]
         best_idx = int(np.argmax(sims))
-        return self.doc_names[best_idx], float(sims[best_idx])
+        doc = self.doc_names[best_idx]
+        score = float(sims[best_idx])
+        self.logger.debug("local route query=%s doc=%s score=%.3f", user_input, doc, score)
+        return doc, score
 
-    def get_document_topic(self, user_input: str, threshold: Optional[float] = None) -> Optional[str]:
+    def get_document_topic(
+        self, user_input: str, threshold: Optional[float] = None
+    ) -> Optional[str]:
         doc, score = self.route(user_input)
         thr = threshold if threshold is not None else self.threshold
         if doc and score >= thr:

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -86,6 +86,7 @@ LLM_DOCS_MCP_HEALTH_URL = os.getenv(
     "LLM_DOCS_MCP_HEALTH_URL",
     LLM_DOCS_MCP_URL.replace("/tools/call", "/health"),
 )
+LLM_DOCS_BASE = os.getenv("LLM_DOCS_BASE")
 # Credenciales opcionales para microservicios
 LLM_DOCS_MCP_USER = os.getenv("LLM_DOCS_MCP_USER")
 LLM_DOCS_MCP_PASSWORD = os.getenv("LLM_DOCS_MCP_PASSWORD")
@@ -183,7 +184,7 @@ DOCUMENT_TOPIC_MAP = load_document_topics_from_files()
 
 # Configuración para el enrutador semántico
 ROUTER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config", "router_config.json")
-semantic_router = SemanticDocumentRouter(ROUTER_CONFIG_PATH)
+semantic_router = SemanticDocumentRouter(ROUTER_CONFIG_PATH, remote_url=LLM_DOCS_BASE)
 
 SPECIFIC_RULES = [
     (["permiso", "aterrizaje"], "RAG-doc_tramites.json"),
@@ -198,21 +199,24 @@ def apply_specific_rules(query: str) -> Optional[str]:
     return None
 
 
-def route_document(query: str) -> Optional[str]:
-    doc_sem, score = semantic_router.route(query)
-    thr = float(os.getenv("SEMANTIC_DOC_THRESHOLD", str(semantic_router.threshold)))
-    if doc_sem and score >= thr:
-        return doc_sem
-
-    q = query.lower()
+def route_by_alias(q: str) -> Optional[str]:
     best_doc, best_score = None, 0
     for doc_name, aliases in DOCUMENT_TOPIC_MAP.items():
         match_count = sum(1 for a in aliases if a in q)
         if match_count > best_score:
             best_doc, best_score = doc_name, match_count
-    if best_doc and best_score > 0:
-        return best_doc
-    return None
+    return best_doc if best_score > 0 else None
+
+
+def route_document(query: str) -> Optional[str]:
+    doc = apply_specific_rules(query)
+    if doc:
+        return doc
+    doc_sem, score = semantic_router.route(query)
+    thr = float(os.getenv("SEMANTIC_DOC_THRESHOLD", str(semantic_router.threshold)))
+    if doc_sem and score >= thr:
+        return doc_sem
+    return route_by_alias(query.lower())
 
 # == Campos requeridos por tool ==
 REQUIRED_FIELDS = {

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -21,6 +21,8 @@ from prometheus_client import (
     generate_latest,
     CONTENT_TYPE_LATEST,
 )
+from pydantic import BaseModel
+from typing import List, Optional
 from llama_client import LlamaClient
 from embeddings import embed
 from qdrant_utils import (
@@ -161,6 +163,34 @@ RAG_LATENCY_HISTOGRAM = Histogram(
     buckets=[0.1, 0.5, 1, 2, 5, 10],
     registry=PROM_REGISTRY,
 )
+
+
+class RouteReq(BaseModel):
+    query: str
+    documents: List[dict]
+    threshold: float = 0.5
+
+
+class RouteResp(BaseModel):
+    name: Optional[str]
+    score: float
+
+
+@app.post("/semantic-route", response_model=RouteResp)
+def semantic_route_api(
+    req: RouteReq, credentials: HTTPBasicCredentials = Depends(authenticate)
+):
+    """Enrutador semántico expuesto vía HTTP."""
+    vecs = embed([req.query] + [d.get("description", "") for d in req.documents])
+    qv, desc_vecs = vecs[0], vecs[1:]
+    sims = cosine_similarity([qv], desc_vecs)[0].tolist() if desc_vecs else []
+    if sims:
+        best_idx = max(range(len(sims)), key=lambda i: sims[i])
+        best_score = float(sims[best_idx])
+        if best_score >= req.threshold:
+            return {"name": req.documents[best_idx].get("name"), "score": best_score}
+        return {"name": None, "score": best_score}
+    return {"name": None, "score": 0.0}
 
 # ==== Utilidades ====
 def load_metadata():


### PR DESCRIPTION
## Summary
- expose semantic document routing as `/semantic-route` API to avoid fragile imports
- add optional remote routing and debug logging in `SemanticDocumentRouter`
- load `LLM_DOCS_BASE` in orchestrator and apply specific-rule plus alias fallback
- clarify router config descriptions for key RAG documents

## Testing
- `pytest` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6891562948c0832fb2120dfd17a18f25