### PR TITLE
Improve department routing and add tests

### DIFF
--- a/mcp-core/department_router.py
+++ b/mcp-core/department_router.py
@@ -1,6 +1,8 @@
+"""Simple keyword-based department router."""
+
 import json
 import os
-from typing import Optional, Dict, List, Any
+from typing import Dict, List, Optional, Any
 
 try:
     from utils.text import normalize_text
@@ -18,6 +20,10 @@ class DepartmentRouter:
     """
     Identifica un departamento específico dentro de una consulta
     basándose en un mapa de alias cargado desde un archivo JSON.
+
+    Se realiza una normalización básica del texto para realizar
+    comparaciones robustas independientemente de mayúsculas, tildes u
+    otros caracteres especiales.
     """
     def __init__(self, departments_path: str):
         self.department_map: Dict[str, str] = {}
@@ -37,8 +43,27 @@ class DepartmentRouter:
         self.sorted_aliases = sorted(self.department_map.keys(), key=len, reverse=True)
 
     def get_department_id(self, user_input: str) -> Optional[str]:
+        """Retorna el ID del departamento asociado al texto del usuario.
+
+        La búsqueda se realiza comprobando si alguno de los alias
+        normalizados está contenido en la consulta normalizada. Si no hay
+        coincidencias se retorna ``None``.
+        """
         normalized_input = normalize_text(user_input)
         for alias in self.sorted_aliases:
             if alias in normalized_input:
                 return self.department_map[alias]
         return None
+
+
+def get_department_id(query: str, router: DepartmentRouter) -> Optional[str]:
+    """Helper para obtener el ID de departamento usando un router.
+
+    Este envoltorio facilita pruebas de humo y mantiene el mismo tipo de
+    retorno que ``DepartmentRouter.get_department_id``.
+    """
+
+    return router.get_department_id(query)
+
+
+__all__ = ["DepartmentRouter", "get_department_id"]

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -1549,12 +1549,18 @@ def orchestrate(
 
     # --- 0.3 (NUEVO) Enrutamiento por departamento específico ---
     department_id = department_router.get_department_id(user_input)
+    logger.debug(
+        f"DepartmentRouter result: {department_id}", extra={"trace_id": trace_id}
+    )
     if department_id:
         logger.info(
             f"Consulta enrutada al departamento ID '{department_id}' por alias.",
             extra={"trace_id": trace_id},
         )
         context_manager.update_context_data(sid, {"selected_department_id": department_id})
+    else:
+        # Si no se detecta un departamento, nos aseguramos de limpiar el contexto
+        context_manager.clear_context_field(sid, "selected_department_id")
     
     # --- 0.5 (NUEVO) Enrutamiento por tema a documento específico ---
     document_topic = apply_specific_rules(user_input) or route_document(user_input)

--- a/mcp-core/tests/test_department_router.py
+++ b/mcp-core/tests/test_department_router.py
@@ -1,0 +1,27 @@
+import sys
+import unittest
+from pathlib import Path
+
+# Ensure mcp-core is importable
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from department_router import DepartmentRouter, get_department_id  # noqa: E402
+
+
+class TestDepartmentRouter(unittest.TestCase):
+    def setUp(self):
+        data_path = ROOT.parent / "services" / "llm_docs-mcp" / "documents" / "RAG-depto_info.json"
+        self.router = DepartmentRouter(str(data_path))
+
+    def test_match_alias(self):
+        q = "email del departamento de coordinacion regional"
+        self.assertEqual(get_department_id(q, self.router), "AI-001-contacto")
+
+    def test_no_match_returns_none(self):
+        q = "informacion sobre parques y jardines"
+        self.assertIsNone(get_department_id(q, self.router))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand department router with helper function and clearer documentation
- log department routing results and clear context on no match
- add unit tests for department routing

## Testing
- `ruff check mcp-core/department_router.py`
- `ruff check mcp-core/tests/test_department_router.py`
- `ruff check mcp-core/orchestrator.py` *(fails: module-level import not at top, unused imports, etc.)*
- `python -m pytest mcp-core/tests/test_department_router.py -q`
- `python - <<'PY'
import sys, os
sys.path.insert(0, os.path.abspath('mcp-core'))
from department_router import DepartmentRouter, get_department_id

path = os.path.join('services', 'llm_docs-mcp', 'documents', 'RAG-depto_info.json')
router = DepartmentRouter(path)
print('OK:', get_department_id('correo del departamento de coordinacion regional', router))
print('NONE:', get_department_id('parques y jardines', router))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689159e5e9fc832fa5180dbb59f2d4cb