### PR TITLE
feat: add API key auth for docs service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
     environment:
       - REDIS_HOST=redis
       - DOCS_DIR=/app/documents
+      - LLM_DOCS_API_KEY=un-valor-secreto-muy-seguro
     ports:
       - "5000:5000"
     networks:
@@ -177,6 +178,7 @@ services:
       - MODEL_PATH=models/phi-2.Q4_K_M.gguf
       - LLM_DOCS_MCP_USER=publilab
       - LLM_DOCS_MCP_PASSWORD=Publ14b#Mun801
+      - LLM_DOCS_API_KEY=un-valor-secreto-muy-seguro
     depends_on:
       - qdrant
     expose:

--- a/mcp-core/.env.sample
+++ b/mcp-core/.env.sample
@@ -7,6 +7,7 @@ LLM_DOCS_MCP_URL=http://llm_docs-mcp:8000/tools/call
 # Credenciales de autenticación para llm_docs-mcp
 LLM_DOCS_MCP_USER=publilab
 LLM_DOCS_MCP_PASSWORD=Publ14b#Mun801
+LLM_DOCS_API_KEY=un-valor-secreto-muy-seguro
 
 # Endpoint de healthcheck del microservicio de documentos
 LLM_DOCS_MCP_HEALTH_URL=http://llm_docs-mcp:8000/health

--- a/mcp-core/document_router.py
+++ b/mcp-core/document_router.py
@@ -1,0 +1,54 @@
+"""Client para el endpoint de enrutamiento semántico de llm_docs-mcp."""
+
+from __future__ import annotations
+
+import os
+import logging
+from typing import List, Optional, Tuple
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+logger = logging.getLogger("document_router")
+
+
+LLM_DOCS_BASE = os.getenv("LLM_DOCS_MCP_BASE", "http://llm_docs-mcp:8000")
+LLM_DOCS_API_KEY = os.getenv("LLM_DOCS_API_KEY")
+LLM_DOCS_MCP_USER = os.getenv("LLM_DOCS_MCP_USER")
+LLM_DOCS_MCP_PASSWORD = os.getenv("LLM_DOCS_MCP_PASSWORD")
+
+
+class SemanticDocumentRouter:
+    """Realiza el enrutamiento llamando al microservicio llm_docs-mcp."""
+
+    def __init__(self) -> None:
+        self.url = f"{LLM_DOCS_BASE}/semantic-route"
+
+    def route(
+        self, query: str, documents: List[dict], threshold: float = 0.5
+    ) -> Tuple[Optional[str], float]:
+        headers = {}
+        auth = None
+        if LLM_DOCS_API_KEY:
+            headers["X-API-KEY"] = LLM_DOCS_API_KEY
+        if LLM_DOCS_MCP_USER and LLM_DOCS_MCP_PASSWORD:
+            auth = HTTPBasicAuth(LLM_DOCS_MCP_USER, LLM_DOCS_MCP_PASSWORD)
+        try:
+            resp = requests.post(
+                self.url,
+                json={"query": query, "documents": documents, "threshold": threshold},
+                headers=headers,
+                auth=auth,
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("name"), float(data.get("score", 0.0))
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Remote routing failed: {e}")
+            return None, 0.0
+
+
+__all__ = ["SemanticDocumentRouter"]
+

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -97,6 +97,7 @@ LLM_DOCS_BASE = os.getenv("LLM_DOCS_BASE") or LLM_DOCS_MCP_URL.replace(
 # Credenciales opcionales para microservicios
 LLM_DOCS_MCP_USER = os.getenv("LLM_DOCS_MCP_USER")
 LLM_DOCS_MCP_PASSWORD = os.getenv("LLM_DOCS_MCP_PASSWORD")
+LLM_DOCS_API_KEY = os.getenv("LLM_DOCS_API_KEY")
 LLM_DOCS_TIMEOUT = int(os.getenv("LLM_DOCS_TIMEOUT", "120"))
 LLM_DOCS_RETRIES = int(os.getenv("LLM_DOCS_RETRIES", "1"))
 LLM_DOCS_CIRCUIT_THRESHOLD = int(
@@ -559,15 +560,22 @@ def call_tool_microservice(tool: str, params: Dict[str, Any], trace_id: str | No
         logger.warning("Circuit breaker open", extra={"trace_id": trace_id})
         return {"error": "circuit_open"}
     auth = None
+    headers: dict[str, str] | None = None
     if tool.startswith("doc-") and LLM_DOCS_MCP_USER and LLM_DOCS_MCP_PASSWORD:
         auth = HTTPBasicAuth(LLM_DOCS_MCP_USER, LLM_DOCS_MCP_PASSWORD)
+    if tool.startswith("doc-") and LLM_DOCS_API_KEY:
+        headers = {"X-API-KEY": LLM_DOCS_API_KEY}
     timeout = LLM_DOCS_TIMEOUT if tool.startswith("doc-") else 30
     retries = LLM_DOCS_RETRIES if tool.startswith("doc-") else 0
     for attempt in range(retries + 1):
         t0 = time.time()
         try:
             resp = requests.post(
-                service_url, json=payload, auth=auth, timeout=timeout
+                service_url,
+                json=payload,
+                auth=auth,
+                headers=headers,
+                timeout=timeout,
             )
             if resp.status_code >= 500:
                 raise requests.HTTPError(response=resp)

--- a/services/llm_docs-mcp/config.env.example
+++ b/services/llm_docs-mcp/config.env.example
@@ -2,6 +2,7 @@
 ALLOWED_IPS=127.0.0.1,192.168.1.100,172.18.0.0/16
 LLM_DOCS_MCP_USER=admin
 LLM_DOCS_MCP_PASSWORD=supersecret
+LLM_DOCS_API_KEY=un-valor-secreto-muy-seguro
 LOG_PATH=/app/gateway.log
 DOCUMENTS_PATH=/documents/
 METADATA_PATH=/documents/metadata.json

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -63,7 +63,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 # Seguridad básica HTTP/IP
-security = HTTPBasic()
+security = HTTPBasic(auto_error=False)
 
 # --- Lista de IPs/Redes permitidas (con soporte para CIDR) ---
 ALLOWED_IPS_STR = os.getenv("ALLOWED_IPS", "127.0.0.1,172.18.0.0/16,testclient")
@@ -82,6 +82,8 @@ for token in ALLOWED_IPS_STR.split(","):
 
 LLM_DOCS_MCP_USER = os.getenv("LLM_DOCS_MCP_USER")
 LLM_DOCS_MCP_PASSWORD = os.getenv("LLM_DOCS_MCP_PASSWORD")
+API_KEY_NAME = "X-API-KEY"
+LLM_DOCS_API_KEY = os.getenv("LLM_DOCS_API_KEY")
 class IPWhitelistMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         # Permitir acceso sin restricciones a endpoints públicos como healthcheck
@@ -103,12 +105,20 @@ class IPWhitelistMiddleware(BaseHTTPMiddleware):
                 return JSONResponse(status_code=403, content={"detail": "IP no autorizada"})
         return await call_next(request)
 app.add_middleware(IPWhitelistMiddleware)
-def authenticate(credentials: HTTPBasicCredentials = Depends(security)):
-    if LLM_DOCS_MCP_USER and credentials.username != LLM_DOCS_MCP_USER:
-        raise HTTPException(status_code=401, detail="Credenciales inválidas")
-    if LLM_DOCS_MCP_PASSWORD and credentials.password != LLM_DOCS_MCP_PASSWORD:
-        raise HTTPException(status_code=401, detail="Credenciales inválidas")
-    return credentials
+
+
+def authenticate(
+    request: Request, credentials: Optional[HTTPBasicCredentials] = Depends(security)
+):
+    api_key = request.headers.get(API_KEY_NAME)
+    if LLM_DOCS_API_KEY and api_key == LLM_DOCS_API_KEY:
+        return True
+    if credentials and (
+        (not LLM_DOCS_MCP_USER or credentials.username == LLM_DOCS_MCP_USER)
+        and (not LLM_DOCS_MCP_PASSWORD or credentials.password == LLM_DOCS_MCP_PASSWORD)
+    ):
+        return True
+    raise HTTPException(status_code=401, detail="Credenciales inválidas")
 
 # ==== Logging estructurado ====
 log_path = os.getenv("LOG_PATH", "gateway.log")


### PR DESCRIPTION
## Summary
- support X-API-KEY authentication in llm_docs-mcp gateway
- send API key from mcp-core document router and orchestrator
- document new LLM_DOCS_API_KEY environment variable in samples and compose

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'llm_docs_mcp')*

------
https://chatgpt.com/codex/tasks/task_e_68962a0110a8832fb35778ae954397d9