### PR TITLE
feat(intent): improve intent classification with greetings rule

### DIFF
--- a/mcp-core/clients/llm_docs.py
+++ b/mcp-core/clients/llm_docs.py
@@ -46,9 +46,12 @@ class LlmDocsClient:
         return r.json()
 
     # --- Alto nivel ---
-    def classify_intent(self, texto: str, trace_id: Optional[str] = None) -> str:
+    def classify_intent(self, texto: str, trace_id: Optional[str] = None) -> dict:
+        """Clasifica la intención y devuelve un dict con intent y entities."""
         resp = self.tools_call("doc-classify_intent_llm", {"texto": texto}, trace_id)
-        return (resp.get("intent") or "").strip()
+        intent = (resp.get("intent") or "").strip()
+        entities = resp.get("entities") or {}
+        return {"intent": intent, "entities": entities}
 
     def doc_generar_respuesta_llm(self, pregunta: str, trace_id: Optional[str] = None, **kwargs) -> dict:
         params = {"pregunta": pregunta} | kwargs

--- a/mcp-core/intent_classifier.py
+++ b/mcp-core/intent_classifier.py
@@ -1,19 +1,59 @@
-from typing import Dict
+import logging
+import re
+import unicodedata
+from typing import Optional, Dict
+
 from .clients.llm_docs import client as llm_client
 
+# --- Utils de normalización y detección de saludos ---
+_GREET_RE = re.compile(r"\b(hola|buenas|buenos dias|buenos días|hello|hi|buenas tardes|buenas noches)\b", re.IGNORECASE)
 
-def classify_intent_and_entities(user_input: str, session_id: str) -> Dict:
+
+def _normalize(text: str) -> str:
+    if not text:
+        return ""
+    # Normaliza tildes y pasa a minúsculas
+    nfkd = unicodedata.normalize("NFKD", text)
+    no_diacritics = "".join(ch for ch in nfkd if not unicodedata.combining(ch))
+    return no_diacritics.casefold().strip()
+
+
+def _is_greeting(text: str, max_tokens: int = 4) -> bool:
+    t = _normalize(text)
+    if not t:
+        return False
+    if _GREET_RE.search(t) and len(t.split()) <= max_tokens:
+        return True
+    return False
+
+
+logger = logging.getLogger("munbot")
+
+
+def classify_intent_and_entities(user_input: str, trace_id: Optional[str] = None) -> Dict:
     """
-    Clasifica la intención principal con llm_docs-mcp y devuelve estructura esperada.
-    (Por ahora, entidades/dominos vacíos; si agregas endpoint de NER, conéctalo aquí.)
+    Clasifica la intención y entidades de la entrada del usuario.
+    - Regla local para saludos: evita golpear LLM/RAG para 'hola', 'buenas', etc.
+    - Llamada correcta al cliente llm_docs: classify_intent(user_input)
+    - Retorno normalizado al orquestador: {"intencion": <str>, "entidades": <dict>}
     """
     try:
-        response = llm_client.generate(prompt=user_input, trace_id=session_id)
-        intent = response.get("text")
-        if not intent:
-            return {"intencion": "no_entendido", "entidades": {}, "dominios": []}
-        return {"intencion": intent, "entidades": {}, "dominios": []}
-    except Exception as e:
-        print(f"Error al clasificar la intención para sesión {session_id}: {e}")
-        return {"intencion": "no_entendido", "entidades": {}, "dominios": []}
+        # 1) Regla local de saludos (hardening)
+        if _is_greeting(user_input):
+            logger.info("[INTENT] Detectado saludo por regla local", extra={"trace_id": trace_id})
+            return {"intencion": "saludo", "entidades": {}}
 
+        # 2) Llamada correcta al cliente llm_docs
+        result = llm_client.classify_intent(user_input)
+
+        # 3) Normalización del payload esperado por el orquestador
+        intent = (result.get("intent") or "").strip() or "no_entendido"
+        entities = result.get("entities") or {}
+
+        logger.info(f"[INTENT] Intención clasificada por llm_docs: {intent}", extra={"trace_id": trace_id})
+        return {"intencion": intent, "entidades": entities}
+
+    except Exception as e:
+        # 4) Fallback controlado y trazable
+        logger.exception(f"Error al clasificar la intención: {e}", extra={"trace_id": trace_id})
+        return {"intencion": "no_entendido", "entidades": {}}


### PR DESCRIPTION
## Summary
- handle greeting intents locally
- call `llm_docs` client to classify intent and entities and normalize output
- expose clients package for reliable imports

## Testing
- `python -m pytest` *(fails: Client.__init__() got an unexpected keyword argument 'app')*
- `docker compose build mcp-core` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6898cc28d604832fbafa4a69c871c00c