### PR TITLE
fix: correct llm docs prompts path

### DIFF
--- a/services/llm_docs-mcp/rag.py
+++ b/services/llm_docs-mcp/rag.py
@@ -26,7 +26,9 @@ redis_client = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=Tr
 
 # --- Rutas y Carga de Datos ---
 DOCUMENTS_PATH = os.path.join(os.path.dirname(__file__), 'documents')
-PROMPTS_PATH = os.path.join(os.path.dirname(__file__), '..", "mcp-core", "prompts')
+PROMPTS_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'mcp-core', 'prompts')
+)
 KNOWLEDGE_BASE = []
 
 def load_knowledge_base():


### PR DESCRIPTION
## Summary
- fix improperly quoted PROMPTS_PATH definition
- ensure PROMPTS_PATH uses an absolute path for stability

## Testing
- `docker compose build llm_docs-mcp && docker compose up -d llm_docs-mcp` *(fails: docker: 'compose' is not a docker command)*
- `docker-compose build llm_docs-mcp && docker-compose up -d llm_docs-mcp` *(fails: connection aborted, no Docker daemon running)*
- `docker exec -it llm_docs-mcp python - <<'PY' ...` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `pytest` *(fails: TypeError: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6898cfac0e80832f841e76d0846af617