### PR TITLE
feat: configure prompt and schema paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       - REDIS_HOST=redis
       - DOCS_DIR=/app/documents
       - HUMAN_ESCALATION_LOG=/app/human_escalations.log
+      - PROMPTS_PATH=/app/mcp-core/prompts
+      - TOOL_SCHEMAS_PATH=/app/mcp-core/tool_schemas
       - LLM_DOCS_MCP_URL=http://llm_docs-mcp:8000/tools/call
       - LLM_DOCS_API_KEY=${LLM_DOCS_API_KEY:-}
       - LLM_DOCS_MCP_USER=${LLM_DOCS_MCP_USER:-}

--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -20,7 +20,17 @@ QDRANT_HOST = os.getenv("QDRANT_HOST", "qdrant")
 QDRANT_PORT = int(os.getenv("QDRANT_PORT", 6333))
 COLLECTION_NAME = os.getenv("QDRANT_COLLECTION", "munbot_docs")
 DOCS_PATH = os.getenv("DOCS_DIR", "/app/documents")
-EMBEDDINGS_DIM = int(os.getenv("EMBEDDINGS_DIM", 384))
+
+
+def _get_dim() -> int:
+    raw = os.getenv("EMBEDDINGS_DIM")
+    try:
+        return int(raw) if raw and raw.strip().isdigit() else 384
+    except Exception:
+        return 384
+
+
+EMBEDDINGS_DIM = _get_dim()
 
 # Permite override mediante argumentos CLI
 parser = argparse.ArgumentParser(description="Indexa documentos RAG en Qdrant")

--- a/services/llm_docs-mcp/scripts/init_qdrant.py
+++ b/services/llm_docs-mcp/scripts/init_qdrant.py
@@ -5,7 +5,17 @@ from qdrant_client import QdrantClient
 from qdrant_client.http import models as qdrant
 
 COLLECTION = os.getenv("QDRANT_COLLECTION", "munbot_docs")
-VECTOR_SIZE = int(os.getenv("EMBEDDINGS_DIM", "384"))
+
+
+def _get_dim() -> int:
+    raw = os.getenv("EMBEDDINGS_DIM")
+    try:
+        return int(raw) if raw and raw.strip().isdigit() else 384
+    except Exception:
+        return 384
+
+
+VECTOR_SIZE = _get_dim()
 QDRANT_HOST = os.getenv("QDRANT_HOST", "qdrant")
 QDRANT_PORT = int(os.getenv("QDRANT_PORT", "6333"))
 


### PR DESCRIPTION
## Summary
- expose PROMPTS_PATH and TOOL_SCHEMAS_PATH for mcp-core
- guard EMBEDDINGS_DIM parsing for llm_docs tooling scripts

## Testing
- `pytest` *(fails: Client.__init__() got an unexpected keyword argument 'app')*


------
https://chatgpt.com/codex/tasks/task_e_6898d773b7b0832f98be3b0e4095438e