### PR TITLE
fix: accept legacy src flag for document indexing

### DIFF
--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -34,7 +34,8 @@ EMBEDDINGS_DIM = _get_embeddings_dim()
 
 # Permite override mediante argumentos CLI
 parser = argparse.ArgumentParser(description="Indexa documentos RAG en Qdrant")
-parser.add_argument("--docs-dir", default=DOCS_PATH)
+# Mantener compatibilidad con versiones previas que usaban --src
+parser.add_argument("--docs-dir", "--src", dest="docs_dir", default=DOCS_PATH)
 parser.add_argument("--collection", default=COLLECTION_NAME)
 args = parser.parse_args()
 DOCS_PATH = args.docs_dir


### PR DESCRIPTION
## Summary
- allow `--src` flag as alias for `--docs-dir` in indexing script so older entrypoints remain compatible

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_689a3ebb0754832fa9b4d6f33281e6df