### PR TITLE
Map question/answer to Spanish keys in indexer

### DIFF
--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -30,6 +30,15 @@ def normalize_item(raw: dict) -> dict:
     Acepta esquemas dispares (FAQ question/answer, Contrib texto:list,
     Ayudas content+metadata) y devuelve el formato mínimo común.
     """
+    # Mapear claves en inglés a español si existen
+    if "question" in raw or "answer" in raw:
+        question = raw.pop("question", None)
+        answer = raw.pop("answer", None)
+        if question is not None:
+            raw["pregunta"] = question
+        if answer is not None:
+            raw["respuesta"] = answer
+
     doc = raw.get("doc") or raw.get("metadata", {}).get("doc") or ""
     fuente = (
         raw.get("fuente")
@@ -42,20 +51,24 @@ def normalize_item(raw: dict) -> dict:
     tags = raw.get("tags") or raw.get("metadata", {}).get("tags") or []
     tags = [str(t).strip() for t in _as_list(tags)]
     if not tags:
-        tags = ["faq"] if ("answer" in raw or "pregunta" in raw) else ["documento"]
+        tags = ["faq"] if ("respuesta" in raw or "pregunta" in raw) else ["documento"]
 
     alias = raw.get("alias") or raw.get("user_says") or []
     alias = [str(a).strip() for a in _as_list(alias)]
 
     meta = dict(raw.get("metadata") or {})
+    if "pregunta" in raw and "pregunta" not in meta:
+        meta["pregunta"] = raw["pregunta"]
+    if "respuesta" in raw and "respuesta" not in meta:
+        meta["respuesta"] = raw["respuesta"]
 
     texto = raw.get("texto")
     if isinstance(texto, list):
         texto = "\n\n".join(str(x) for x in texto)
 
     if not texto:
-        if "answer" in raw:
-            texto = raw["answer"]
+        if "respuesta" in raw:
+            texto = raw["respuesta"]
             if raw.get("user_says"):
                 alias += [str(a).strip() for a in _as_list(raw["user_says"])]
         elif "content" in raw:

--- a/services/llm_docs-mcp/test_index_documents.py
+++ b/services/llm_docs-mcp/test_index_documents.py
@@ -1,0 +1,34 @@
+import pytest
+import sys
+import types
+
+# Stub embeddings to avoid heavy model download during tests
+fake_embeddings = types.ModuleType("embeddings")
+def fake_embed(texts, batch_size=32):
+    return [[0.0] * 384 for _ in texts]
+fake_embeddings.embed = fake_embed
+sys.modules["embeddings"] = fake_embeddings
+
+# Avoid argparse from reading pytest's arguments during import
+sys.argv = ["index_documents.py"]
+
+from scripts.index_documents import normalize_item
+
+
+def test_normalize_item_maps_question_answer_to_spanish_keys():
+    raw = {
+        "question": "¿Cuál es el horario?",
+        "answer": "De 9 a 17",
+        "metadata": {},
+    }
+
+    result = normalize_item(raw)
+
+    assert "question" not in raw and "answer" not in raw
+    assert raw["pregunta"] == "¿Cuál es el horario?"
+    assert raw["respuesta"] == "De 9 a 17"
+
+    assert result["metadata"]["pregunta"] == "¿Cuál es el horario?"
+    assert result["metadata"]["respuesta"] == "De 9 a 17"
+    assert result["texto"] == "De 9 a 17"
+


### PR DESCRIPTION
## Summary
- normalize `question`/`answer` into Spanish `pregunta`/`respuesta` in document indexing
- build text from `respuesta` and store `pregunta`/`respuesta` in metadata
- add unit test ensuring Spanish keys are produced

## Testing
- `pytest services/llm_docs-mcp/test_index_documents.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3569e2680832faaaafc5d70154ce6