### PR TITLE
Expand query alias matching by document ID

### DIFF
--- a/services/llm_docs-mcp/rag.py
+++ b/services/llm_docs-mcp/rag.py
@@ -67,7 +67,8 @@ def expand_query_with_aliases(
     if selected_doc:
         for it in kb_items:
             doc_val = it.get("doc") or it.get("payload", {}).get("doc")
-            if doc_val == selected_doc:
+            id_val = it.get("id") or it.get("metadata", {}).get("id")
+            if selected_doc in (doc_val, id_val):
                 aliases += it.get("alias") or it.get("payload", {}).get("alias") or []
         aliases = list(dict.fromkeys(a.strip() for a in aliases if a))[:max_aliases]
         if aliases:

--- a/services/llm_docs-mcp/test_expand_query_with_aliases.py
+++ b/services/llm_docs-mcp/test_expand_query_with_aliases.py
@@ -1,0 +1,78 @@
+import os
+import sys
+import types
+
+# Stub external dependencies before importing rag
+fake_llama_client = types.ModuleType("llama_client")
+
+
+class FakeLlamaClient:
+    def generate(self, *a, **k):
+        return "ok"
+
+
+fake_llama_client.LlamaClient = FakeLlamaClient
+sys.modules["llama_client"] = fake_llama_client
+
+fake_embeddings = types.ModuleType("embeddings")
+
+
+def fake_embed(texts, batch_size=32):
+    return [[0.0] for _ in texts]
+
+
+fake_embeddings.embed = fake_embed
+sys.modules["embeddings"] = fake_embeddings
+
+fake_qdrant_utils = types.ModuleType("qdrant_utils")
+
+
+def _dummy(*a, **k):
+    return None
+
+
+fake_qdrant_utils.search_in_qdrant = lambda *a, **k: []
+fake_qdrant_utils.filter_by_document = _dummy
+fake_qdrant_utils.filter_by_procedure_id = _dummy
+fake_qdrant_utils.filter_by_department_id = _dummy
+fake_qdrant_utils.filter_by_domain = _dummy
+fake_qdrant_utils.combine_filters = _dummy
+sys.modules["qdrant_utils"] = fake_qdrant_utils
+
+fake_sentence_transformers = types.ModuleType("sentence_transformers")
+
+
+class FakeCrossEncoder:
+    def __init__(self, *a, **k):
+        pass
+
+    def predict(self, pairs):
+        return [0.0] * len(pairs)
+
+
+fake_sentence_transformers.CrossEncoder = FakeCrossEncoder
+sys.modules["sentence_transformers"] = fake_sentence_transformers
+
+sys.path.insert(0, os.path.dirname(__file__))
+from rag import expand_query_with_aliases
+
+
+def test_expand_query_with_aliases_match_doc_and_id():
+    kb = [
+        {"doc": "DocA", "alias": ["a1", "a2"], "id": "ID_A"},
+        {
+            "payload": {"doc": "DocB", "alias": ["b1", "b2"]},
+            "metadata": {"id": "ID_B"},
+        },
+    ]
+    q = "consulta"
+    assert expand_query_with_aliases(q, "DocA", kb) == "consulta a1 a2"
+    assert expand_query_with_aliases(q, "ID_B", kb) == "consulta b1 b2"
+
+
+def test_expand_query_with_aliases_dedup_limit():
+    kb = [{"doc": "DocC", "alias": ["c1", "c1", "c2", "c3"], "id": "ID_C"}]
+    q = "consulta"
+    res = expand_query_with_aliases(q, "DocC", kb, max_aliases=2)
+    assert res == "consulta c1 c2"
+


### PR DESCRIPTION
## Summary
- Support alias expansion when selected document matches either its `doc` value or `id`
- Add tests validating alias expansion, deduplication, and alias limit

## Testing
- `pytest services/llm_docs-mcp/test_expand_query_with_aliases.py -q`
- `pytest tests/test_document_rag.py -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest services/llm_docs-mcp/test_tools.py -q` *(fails: ImportError: cannot import name 'filter_by_domain' from 'qdrant_utils')*

------
https://chatgpt.com/codex/tasks/task_e_68a373020db4832fb36a8f0c8e8ffe8d