### PR TITLE
Refactor intent classifier to use RAG engine with LLM fallback

### DIFF
--- a/services/llm_docs-mcp/intent_classifier.py
+++ b/services/llm_docs-mcp/intent_classifier.py
@@ -1,100 +1,106 @@
 # services/llm_docs-mcp/intent_classifier.py
-"""
-Módulo unificado para la clasificación de intenciones.
-
-Este módulo centraliza toda la lógica para determinar la intención del usuario,
-utilizando un `IntentEngine` basado en datos y un LLM como fallback. Reemplaza
-implementaciones anteriores y elimina la duplicación de criterios.
-
-Funciones principales:
-- `classify_main_intent`: Clasifica la intención principal de una consulta.
-- `classify_reclamo_response`: Clasifica respuestas afirmativas/negativas en flujos específicos.
-"""
 from __future__ import annotations
+
 import os
-from typing import Optional, Dict, Any
+from typing import Optional
+
 from llama_client import LlamaClient
 from intent_engine import classify_intent_payload
 
-_VALID_INTENTS = {"faq", "documento", "agenda", "reclamo", "tramite", "n/a"}
-_INTENT_OUTPUT_MODE = os.getenv("INTENT_OUTPUT_MODE", "rich")
 
-_SLOT_MAP = {
+_VALID = {"faq", "documento", "agenda", "reclamo", "tramite", "n/a"}
+
+_SHARED: Optional[LlamaClient] = None
+
+
+def set_llm_client(client: LlamaClient) -> None:
+    """Share an LLM client instance across calls."""
+
+    global _SHARED
+    _SHARED = client
+
+
+def _llm() -> LlamaClient:
+    """Return the shared LLM client or create a new one."""
+
+    return _SHARED or LlamaClient()
+
+
+# "flat" → devuelve string (compat con gateway/orchestrator actuales)
+# "rich" → devuelve dict con intent/sub_intent/doc/slot/confidence (recomendado)
+_MODE = os.getenv("INTENT_OUTPUT_MODE", "flat").lower()
+
+
+# normalización de nombres legacy a los slots del engine
+_SLOT_NORMALIZE = {
     "horario": "horario_atencion",
     "vigencia": "tiempo_validez",
 }
 
-_SHARED_LLM_CLIENT: Optional[LlamaClient] = None
 
-def set_llm_client(client: LlamaClient) -> None:
-    """Establece un cliente LLM compartido para ser reutilizado."""
-    global _SHARED_LLM_CLIENT
-    _SHARED_LLM_CLIENT = client
+def _norm_slot(s: Optional[str]) -> Optional[str]:
+    if not s:
+        return s
+    return _SLOT_NORMALIZE.get(s, s) if (s := s.strip()) else s
 
-def _get_llm_client() -> LlamaClient:
-    """Obtiene el cliente LLM compartido o crea uno nuevo si no existe."""
-    return _SHARED_LLM_CLIENT or LlamaClient()
 
-def classify_main_intent(user_input: str, llm: LlamaClient | None = None, output_mode: str | None = None) -> Dict[str, Any]:
-    """
-    Clasifica la intención principal del usuario usando el IntentEngine y un LLM como fallback.
+def classify_intent_with_llm(user_input: str, llm: LlamaClient | None = None):
+    """Classify a user's intent using the RAG engine with an LLM fallback."""
 
-    Args:
-        user_input: El texto ingresado por el usuario.
-        llm: Un cliente Llama opcional. Si no se provee, se usará el cliente compartido.
-        output_mode: 'rich' o 'flat'. Si se provee, sobreescribe la variable de entorno.
-
-    Returns:
-        Un diccionario con la intención y detalles adicionales.
-        Ej: {"intent": "agenda", "sub_intent": "reservar", ...}
-    """
     text = (user_input or "").strip()
     if not text:
-        return {"intent": "n/a"}
+        return "n/a" if _MODE == "flat" else {"intent": "n/a"}
 
-    # 1. Clasificación primaria con el IntentEngine
-    rich_result = classify_intent_payload(text)
+    # 1) IntentEngine primero (usa RAG + alias + tags)
+    rich = classify_intent_payload(text)
 
-    # 2. Si el engine no está seguro, usar LLM como desambiguador
-    if rich_result.get("intent") == "n/a":
-        client = llm or _get_llm_client()
+    # 2) Fallback: si el engine no está seguro, pedir SOLO la superclase al LLM
+    if rich.get("intent") == "n/a":
+        client = llm or _llm()
         prompt = (
-            "Clasifica la consulta en una sola categoría: faq, documento, agenda, reclamo, tramite, n/a.\n"
-            "Responde SOLO con una de esas palabras.\n"
+            "Clasifica la consulta EXACTAMENTE en una de estas categorías:\n"
+            "faq | documento | agenda | reclamo | tramite | n/a\n\n"
+            "Reglas:\n"
+            "- Responde SOLO con una palabra del listado.\n"
+            "- No inventes categorías.\n\n"
             f"Consulta: {text}\n"
             "Etiqueta:"
         )
-        llm_guess = (client.generate(prompt, temperature=0) or "").strip().lower()
-        if llm_guess in _VALID_INTENTS:
-            rich_result["intent"] = llm_guess
+        guess = (client.generate(prompt, temperature=0) or "").strip().lower()
+        if guess in _VALID:
+            rich["intent"] = guess
 
-    # 3. Normalizar slots para consistencia
-    slot = rich_result.get("slot")
-    if slot in _SLOT_MAP:
-        rich_result["slot"] = _SLOT_MAP[slot]
+    # 3) Normalización leve de slots por compat (si tu heurística añade 'horario'/'vigencia')
+    if rich.get("slot"):
+        rich["slot"] = _norm_slot(rich["slot"])
+    if rich.get("sub_intent"):
+        rich["sub_intent"] = _norm_slot(rich["sub_intent"])
 
-    # 4. Adaptar salida según el modo
-    mode = output_mode or _INTENT_OUTPUT_MODE
-    if mode == 'flat':
-        return {"intent": rich_result.get("intent")}
-    
-    return rich_result
+    # 4) Salida por modo
+    if _MODE == "flat":
+        # Si quieres compat extrema con flujos viejos:
+        # devolver "saludo" cuando sea faq+saludo
+        sub = (rich.get("sub_intent") or "").lower()
+        if rich["intent"] == "faq" and sub in {"saludo", "despedida", "agradecimiento"}:
+            return sub
+        return rich["intent"]
+    else:
+        return rich
+
+
+# Backwards compatibility for existing callers
+classify_main_intent = classify_intent_with_llm
+
 
 def classify_reclamo_response(text: str) -> str:
-    """
-    Clasifica una respuesta dentro de un flujo de reclamo como afirmativa, negativa o pregunta.
+    """Classify a response within the complaints flow."""
 
-    Args:
-        text: El texto de la respuesta del usuario.
-
-    Returns:
-        'affirmative', 'negative', 'question', o 'unknown'.
-    """
     t = text.lower().strip()
-    if any(word in t for word in ['?', 'saber']):
-        return 'question'
-    if t.startswith('si') or t.startswith('sí') or ' sí' in t:
-        return 'affirmative'
-    if t.startswith('no') or ' no' in t:
-        return 'negative'
-    return 'unknown'
+    if any(word in t for word in ["?", "saber"]):
+        return "question"
+    if t.startswith("si") or t.startswith("sí") or " sí" in t:
+        return "affirmative"
+    if t.startswith("no") or " no" in t:
+        return "negative"
+    return "unknown"
+

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -4,12 +4,18 @@ import os
 import pytest
 import importlib.util
 
+# For rich output in tests
+os.environ["INTENT_OUTPUT_MODE"] = "rich"
+
 # Añadir las rutas necesarias al path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp')))
 
+# Remove any stubbed module from other tests
+sys.modules.pop("intent_classifier", None)
+
 # Ahora las importaciones deberían funcionar
-from intent_classifier import classify_reclamo_response, classify_main_intent
+from intent_classifier import classify_reclamo_response, classify_intent_with_llm
 
 # --- Pruebas para la lógica de clasificación de respuestas de reclamos ---
 
@@ -57,7 +63,7 @@ class MockIntentEngine:
 
 @pytest.fixture(autouse=True)
 def override_dependencies(monkeypatch):
-    monkeypatch.setattr("intent_classifier._get_llm_client", lambda: MockLlamaClient())
+    monkeypatch.setattr("intent_classifier._llm", lambda: MockLlamaClient())
     monkeypatch.setattr("intent_classifier.classify_intent_payload", MockIntentEngine().classify)
 
 
@@ -72,7 +78,7 @@ def override_dependencies(monkeypatch):
 ])
 def test_classify_main_intent_basic(user_input, expected_intent):
     """Prueba la clasificación de intenciones principales para entradas comunes."""
-    result = classify_main_intent(user_input)
+    result = classify_intent_with_llm(user_input)
     
     # Comparamos solo las claves que nos interesan para la prueba
     assert result.get("intent") == expected_intent.get("intent")


### PR DESCRIPTION
## Summary
- replace intent classifier with RAG-first design and LLM fallback
- expose flat and rich output modes with slot normalization
- adjust tests for new classifier interface

## Testing
- `pytest tests/test_intent_classifier.py`
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68a3adc8b0ec832fa60ef31840a8fef2