### PR TITLE
Index answer variants and user phrases for intent engine

### DIFF
--- a/services/llm_docs-mcp/intent_engine.py
+++ b/services/llm_docs-mcp/intent_engine.py
@@ -18,6 +18,42 @@ def _norm(s: str) -> str:
 def _tokenize(s: str) -> List[str]:
     return [t for t in _norm(s).split() if t]
 
+
+def normalize_for_search(s: str) -> str:
+    """Normalize text to improve search indexing.
+
+    Lowercase, remove diacritics and collapse repeated whitespace.
+    """
+    return _norm(s)
+
+
+def build_searchable_text(obj: dict) -> str:
+    """Create a normalized blob of text from all relevant fields."""
+    # Campos principales
+    title = obj.get("title") or obj.get("question") or ""
+    text = obj.get("text") or obj.get("answer") or ""
+
+    # NUEVO: incluir variantes de respuesta
+    answer_variants = obj.get("answer_variant") or []
+
+    # Alias y frases de usuario
+    alias = obj.get("alias") or []
+    user_says = obj.get("user_says") or []
+
+    # Metadatos y tags
+    md = obj.get("metadata") or {}
+    tags = md.get("tags") or obj.get("tags") or []
+    subcat = md.get("subcategory") or ""
+
+    parts = [title, text, subcat]
+    parts.extend(tags)
+    parts.extend(alias)
+    parts.extend(user_says)
+    parts.extend(answer_variants)
+
+    blob = " ".join([p for p in parts if p])
+    return normalize_for_search(blob)
+
 @dataclass
 class Item:
     source: str
@@ -31,13 +67,16 @@ class Item:
 
     def searchable_text(self) -> str:
         # concatena campos relevantes para el fallback
-        parts = []
-        parts += self.alias
-        parts += _ensure_list(self.metadata.get("user_says"))
-        if self.title: parts.append(self.title)
-        if self.texto: parts.append(self.texto)
-        parts += self.tags
-        return " | ".join(parts)
+        obj = {
+            "title": self.title,
+            "text": self.texto,
+            "alias": self.alias,
+            "user_says": _ensure_list(self.metadata.get("user_says")),
+            "answer_variant": _ensure_list(self.metadata.get("answer_variant")),
+            "metadata": self.metadata,
+            "tags": self.tags,
+        }
+        return build_searchable_text(obj)
 
 def _ensure_list(v) -> List[str]:
     if not v: return []
@@ -50,14 +89,23 @@ def load_all() -> List[Item]:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         for obj in data:
+            alias_list = _ensure_list(obj.get("alias"))
+            user_says = _ensure_list(obj.get("user_says"))
+            answer_variants = _ensure_list(obj.get("answer_variant") or obj.get("answer_variants"))
+            meta = obj.get("metadata") or {}
+            if user_says:
+                meta["user_says"] = user_says
+            if answer_variants:
+                meta["answer_variant"] = answer_variants
+            alias_norm = [_norm(a) for a in alias_list + user_says]
             items.append(Item(
                 source = obj.get("fuente") or path,
                 doc    = obj.get("doc"),
                 texto  = obj.get("texto") or "",
                 tags   = _ensure_list(obj.get("tags")),
-                alias  = [ _norm(a) for a in _ensure_list(obj.get("alias")) ],
-                metadata = obj.get("metadata") or {},
-                title    = obj.get("metadata",{}).get("title"),
+                alias  = alias_norm,
+                metadata = meta,
+                title    = meta.get("title"),
             ))
     return items
 

--- a/services/llm_docs-mcp/rag.py
+++ b/services/llm_docs-mcp/rag.py
@@ -66,10 +66,15 @@ def expand_query_with_aliases(
 
     if selected_doc:
         for it in kb_items:
-            # Access 'doc' and 'alias' directly from the item or its payload
-            # as normalize_item ensures their presence.
+            # Access 'doc', 'id' and 'alias' directly from the item or its payload
+            # as normalize_item ensures their presence when available.
             current_doc = it.get("doc") or it.get("payload", {}).get("doc")
-            if current_doc == selected_doc:
+            current_id = (
+                it.get("id")
+                or it.get("metadata", {}).get("id")
+                or it.get("payload", {}).get("metadata", {}).get("id")
+            )
+            if current_doc == selected_doc or current_id == selected_doc:
                 item_aliases = it.get("alias") or it.get("payload", {}).get("alias") or []
                 aliases.extend(item_aliases)
         aliases = list(dict.fromkeys(a.strip() for a in aliases if a))[:max_aliases]

--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -70,7 +70,22 @@ def _valid_vec(v):
         all(isinstance(x, (float, int)) and x == x and x not in (float("inf"), float("-inf")) for x in v)
     )
 
-def normalize_item(item: Dict[str, Any], filename: str) -> Dict[str, Any]:
+def normalize_item(item: Dict[str, Any], filename: str = "") -> Dict[str, Any]:
+    # Normaliza llaves en español si vienen como question/answer y actualiza metadata
+    q = item.pop("question", None)
+    a = item.pop("answer", None)
+    if q is not None:
+        item["pregunta"] = q
+    if a is not None:
+        item["respuesta"] = a
+
+    meta = item.get("metadata") or {}
+    if q is not None:
+        meta["pregunta"] = q
+    if a is not None:
+        meta["respuesta"] = a
+    item["metadata"] = meta
+
     # 1) Texto robusto
     if "texto" in item:
         t = item["texto"]
@@ -78,17 +93,13 @@ def normalize_item(item: Dict[str, Any], filename: str) -> Dict[str, Any]:
     elif "content" in item:
         c = item["content"]
         texto = " ".join(c) if isinstance(c, list) else str(c)
-    elif "answer" in item or "respuesta" in item:
-        # Soporta FAQ antiguos (question/answer) o (pregunta/respuesta)
-        q = item.get("question") or item.get("pregunta") or ""
-        a = item.get("answer") or item.get("respuesta") or ""
-        texto = f"Pregunta frecuente: {q}\nRespuesta: {a}".strip()
+    elif "respuesta" in item or a is not None:
+        texto = item.get("respuesta") or a or ""
     else:
         # Último recurso: concatena strings sueltos
         texto = " ".join(str(v) for v in item.values() if isinstance(v, str))
 
     # 2) Doc / Fuente
-    meta = item.get("metadata") or {}
     doc = item.get("doc") or meta.get("source_doc") or meta.get("doc") or "desconocido"
     fuente = item.get("fuente") or filename
 
@@ -107,6 +118,8 @@ def normalize_item(item: Dict[str, Any], filename: str) -> Dict[str, Any]:
         "title": meta.get("title"),
         "source_doc": meta.get("source_doc") or doc,
         "raw": meta.get("raw"),  # opcional
+        "pregunta": meta.get("pregunta"),
+        "respuesta": meta.get("respuesta"),
     }
 
     return {


### PR DESCRIPTION
## Summary
- Build normalized search blob including title, text, tags, aliases, user phrases, and answer variants for the intent engine
- Persist `user_says` and `answer_variant` metadata and fold them into alias lists
- Expand query alias matching to respect document IDs and sanitize RAG item normalization

## Testing
- `pytest services/llm_docs-mcp -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace099e778832fb7c220a9353b986e