### PR TITLE
feat: include extended metadata in indexer

### DIFF
--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -120,6 +120,17 @@ def normalize_item(item: Dict[str, Any], filename: str = "") -> Dict[str, Any]:
         "raw": meta.get("raw"),  # opcional
         "pregunta": meta.get("pregunta"),
         "respuesta": meta.get("respuesta"),
+        "tema": meta.get("tema"),
+        "tipo_fragmento": meta.get("tipo_fragmento"),
+        "seccion": meta.get("seccion"),
+        "priority": meta.get("priority"),
+        "faq_id": meta.get("faq_id"),
+        # opcionales adicionales
+        "nivel_normativo": meta.get("nivel_normativo"),
+        "vigencia_inicio": meta.get("vigencia_inicio"),
+        "vigencia_fin": meta.get("vigencia_fin"),
+        "version": meta.get("version"),
+        "last_updated": meta.get("last_updated"),
     }
 
     return {


### PR DESCRIPTION
## Summary
- include additional metadata fields like tema, tipo_fragmento, seccion and more when normalizing items for indexing

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68ace8d7e408832fa1925ec5783afaca