### PR TITLE
Include metadata fields in searchable text

### DIFF
--- a/services/llm_docs-mcp/intent_engine.py
+++ b/services/llm_docs-mcp/intent_engine.py
@@ -45,11 +45,22 @@ def build_searchable_text(obj: dict) -> str:
     tags = md.get("tags") or obj.get("tags") or []
     subcat = md.get("subcategory") or ""
 
+    # Extra metadata fields to include in the searchable text
+    extra_md_fields = [
+        md.get("category"),
+        md.get("tema"),
+        md.get("tipo_fragmento"),
+        md.get("seccion"),
+        md.get("priority"),
+        md.get("faq_id"),
+    ]
+
     parts = [title, text, subcat]
     parts.extend(tags)
     parts.extend(alias)
     parts.extend(user_says)
     parts.extend(answer_variants)
+    parts.extend(str(f) for f in extra_md_fields if f not in (None, ""))
 
     blob = " ".join([p for p in parts if p])
     return normalize_for_search(blob)

--- a/services/llm_docs-mcp/test_searchable_text_metadata.py
+++ b/services/llm_docs-mcp/test_searchable_text_metadata.py
@@ -1,0 +1,21 @@
+from intent_engine import build_searchable_text
+
+
+def test_metadata_fields_included_in_searchable_text():
+    obj = {
+        "title": "Titulo",
+        "text": "Texto",
+        "metadata": {
+            "category": "Cat1",
+            "tema": "Tema2",
+            "tipo_fragmento": "Frag3",
+            "seccion": "Sec4",
+            "priority": 7,
+            "faq_id": "Faq5",
+        },
+    }
+
+    result = build_searchable_text(obj)
+
+    for token in ["cat1", "tema2", "frag3", "sec4", "7", "faq5"]:
+        assert token in result


### PR DESCRIPTION
## Summary
- include category, tema, tipo_fragmento, seccion, priority and faq_id metadata in intent engine searchable text
- test searchable text includes new metadata fields

## Testing
- `pytest services/llm_docs-mcp`

------
https://chatgpt.com/codex/tasks/task_e_68ace9e2d600832f887cb815dde73260