### PR TITLE
Merge global metadata into document chunks

### DIFF
--- a/services/llm_docs-mcp/scripts/index_documents.py
+++ b/services/llm_docs-mcp/scripts/index_documents.py
@@ -127,6 +127,7 @@ def normalize_item(item: Dict[str, Any], filename: str = "") -> Dict[str, Any]:
         "faq_id": meta.get("faq_id"),
         # opcionales adicionales
         "nivel_normativo": meta.get("nivel_normativo"),
+        "peso_normativo": meta.get("peso_normativo"),
         "vigencia_inicio": meta.get("vigencia_inicio"),
         "vigencia_fin": meta.get("vigencia_fin"),
         "version": meta.get("version"),
@@ -181,6 +182,15 @@ COLLECTION_NAME = args.collection
 def load_rag_json_chunks(directory: str) -> list[dict]:
     """Carga todos los archivos RAG-*.json y normaliza cada entrada."""
     items: list[dict] = []
+    metadata_path = os.path.join(directory, "metadata.json")
+    metadata_map: dict[str, dict] = {}
+    if os.path.isfile(metadata_path):
+        try:
+            with open(metadata_path, "r", encoding="utf-8") as f:
+                metadata_map = json.load(f)
+        except Exception as e:
+            logger.error(f"Error cargando metadata global: {e}")
+
     for filename in os.listdir(directory):
         if filename.startswith("RAG-") and filename.endswith(".json"):
             filepath = os.path.join(directory, filename)
@@ -192,8 +202,23 @@ def load_rag_json_chunks(directory: str) -> list[dict]:
                 data = None
             if not data:
                 continue
+
+            global_meta = metadata_map.get(filename, {})
             for raw in data:
-                item = normalize_item(raw, filename) # Pass filename to normalize_item
+                raw_meta = raw.get("metadata") or {}
+                for k in [
+                    "nivel_normativo",
+                    "peso_normativo",
+                    "vigencia_inicio",
+                    "vigencia_fin",
+                    "version",
+                    "last_updated",
+                ]:
+                    if k in global_meta and k not in raw_meta:
+                        raw_meta[k] = global_meta[k]
+                raw["metadata"] = raw_meta
+
+                item = normalize_item(raw, filename)
                 if item:
                     items.append(item)
     return items

--- a/services/llm_docs-mcp/test_index_documents.py
+++ b/services/llm_docs-mcp/test_index_documents.py
@@ -12,7 +12,8 @@ sys.modules["embeddings"] = fake_embeddings
 # Avoid argparse from reading pytest's arguments during import
 sys.argv = ["index_documents.py"]
 
-from scripts.index_documents import normalize_item
+from scripts.index_documents import normalize_item, load_rag_json_chunks, make_payload
+import json
 
 
 def test_normalize_item_maps_question_answer_to_spanish_keys():
@@ -31,4 +32,27 @@ def test_normalize_item_maps_question_answer_to_spanish_keys():
     assert result["metadata"]["pregunta"] == "¿Cuál es el horario?"
     assert result["metadata"]["respuesta"] == "De 9 a 17"
     assert result["texto"] == "De 9 a 17"
+
+
+def test_load_rag_json_chunks_merges_global_metadata(tmp_path):
+    meta = {
+        "RAG-test.json": {
+            "nivel_normativo": "Ley",
+            "peso_normativo": "0.7",
+            "vigencia_inicio": "2024-01-01",
+            "vigencia_fin": "2024-12-31",
+            "version": "1.0",
+            "last_updated": "2024-02-02",
+        }
+    }
+    (tmp_path / "metadata.json").write_text(json.dumps(meta), encoding="utf-8")
+
+    rag_data = [{"doc": "Doc", "texto": "contenido", "metadata": {}}]
+    (tmp_path / "RAG-test.json").write_text(json.dumps(rag_data), encoding="utf-8")
+
+    items = load_rag_json_chunks(str(tmp_path))
+    assert len(items) == 1
+    payload = make_payload(items[0])
+    for k, v in meta["RAG-test.json"].items():
+        assert payload["metadata"][k] == v
 


### PR DESCRIPTION
## Summary
- merge file-level metadata into document chunks before normalization
- include `peso_normativo` and other global fields in chunk metadata
- add test covering metadata merge into indexing payload

## Testing
- `pytest services/llm_docs-mcp`


------
https://chatgpt.com/codex/tasks/task_e_68acedbce07c832fbff93372b72543ca