### PR TITLE
feat: add smalltalk fastpath to intent classifier

### DIFF
--- a/services/llm_docs-mcp/intent_classifier.py
+++ b/services/llm_docs-mcp/intent_classifier.py
@@ -2,13 +2,25 @@
 from __future__ import annotations
 
 import os
+import re
+import logging
 from typing import Optional
 
 from llama_client import LlamaClient
 from intent_engine import classify_intent_payload
+from text_utils import normalize_for_search
 
 
 _VALID = {"faq", "documento", "agenda", "reclamo", "tramite", "n/a"}
+
+# Compiled patterns for smalltalk fast-path
+SALUDO_PAT = re.compile(r"\b(hola|buen[oa]s(?:\s*(dias|tardes|noches))?|que tal|como estas)\b", re.I)
+DESPEDIDA_PAT = re.compile(r"\b(adios|chao|hasta luego|nos vemos|hasta pronto|cuidate)\b", re.I)
+GRACIAS_PAT = re.compile(r"\b(gracias|muchas gracias|mil gracias|se agradece)\b", re.I)
+
+ENABLE_FASTPATH_SMALLTALK = os.getenv("ENABLE_FASTPATH_SMALLTALK", "1") == "1"
+
+logger = logging.getLogger(__name__)
 
 _SHARED: Optional[LlamaClient] = None
 
@@ -44,10 +56,33 @@ def _norm_slot(s: Optional[str]) -> Optional[str]:
     return _SLOT_NORMALIZE.get(s, s) if (s := s.strip()) else s
 
 
+def fastpath_smalltalk(user_text: str):
+    t = normalize_for_search(user_text)
+    if not t or t in {":)", ":(", "👍", "👋"}:
+        return None
+    if len(t.split()) <= 3 and SALUDO_PAT.search(t):
+        return {"intent": "faq", "sub_intent": "saludo", "source": "fastpath"}
+    if DESPEDIDA_PAT.search(t):
+        return {"intent": "faq", "sub_intent": "despedida", "source": "fastpath"}
+    if GRACIAS_PAT.search(t):
+        return {"intent": "faq", "sub_intent": "agradecimiento", "source": "fastpath"}
+    return None
+
+
 def classify_intent_with_llm(user_input: str, llm: LlamaClient | None = None, mode: str | None = None):
     """Classify a user's intent using the RAG engine with an LLM fallback."""
 
     text = (user_input or "").strip()
+    if ENABLE_FASTPATH_SMALLTALK:
+        fp = fastpath_smalltalk(user_input)
+        logger.debug({"stage": "fastpath_smalltalk", "hit": bool(fp), "text": user_input[:80]})
+        if fp:
+            output_mode = mode or _MODE
+            if output_mode == "flat":
+                if fp["sub_intent"] in {"saludo", "despedida", "agradecimiento"}:
+                    return fp["sub_intent"]
+                return fp["intent"]
+            return fp
     if not text:
         return "n/a" if (mode or _MODE) == "flat" else {"intent": "n/a"}
 

--- a/services/llm_docs-mcp/text_utils.py
+++ b/services/llm_docs-mcp/text_utils.py
@@ -1,0 +1,13 @@
+import unicodedata
+import re
+
+_WS = re.compile(r"\s+")
+_PUNCT = re.compile(r"[^\w\sáéíóúñü]")  # conserva letras y tildes básicas
+
+def normalize_for_search(s: str) -> str:
+    s = s.lower()
+    s = unicodedata.normalize("NFKD", s)
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))  # quita diacríticos
+    s = _PUNCT.sub(" ", s)
+    s = _WS.sub(" ", s).strip()
+    return s

--- a/tests/test_fastpath_smalltalk.py
+++ b/tests/test_fastpath_smalltalk.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import pytest
+
+# ensure rich output for tests
+os.environ["INTENT_OUTPUT_MODE"] = "rich"
+
+# add service path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'services', 'llm_docs-mcp')))
+
+# remove cached module if any
+sys.modules.pop("intent_classifier", None)
+
+from intent_classifier import fastpath_smalltalk, classify_intent_with_llm
+
+
+@pytest.mark.parametrize("text, expected", [
+    ("hola", "saludo"),
+    ("buenas tardes", "saludo"),
+    ("que tal", "saludo"),
+    ("como estas", "saludo"),
+    ("adios", "despedida"),
+    ("chao", "despedida"),
+    ("hasta luego", "despedida"),
+    ("nos vemos", "despedida"),
+    ("gracias", "agradecimiento"),
+    ("muchas gracias", "agradecimiento"),
+    ("se agradece", "agradecimiento"),
+])
+def test_fastpath_hits(text, expected):
+    res = fastpath_smalltalk(text)
+    assert res and res["sub_intent"] == expected
+
+
+def test_fastpath_no_hit():
+    for txt in ["permiso de circulación", "agenda hora", "certificado de residencia"]:
+        assert fastpath_smalltalk(txt) is None
+
+
+def test_fastpath_mixed_message():
+    assert fastpath_smalltalk("hola, necesito un certificado") is None
+
+
+def test_classify_intent_uses_fastpath(monkeypatch):
+    # make sure engine is not called if fastpath hits
+    def _fail(_):
+        raise AssertionError("engine should not be called")
+    monkeypatch.setattr("intent_classifier.classify_intent_payload", _fail)
+    result = classify_intent_with_llm("hola")
+    assert result.get("intent") == "faq"
+    assert result.get("sub_intent") == "saludo"


### PR DESCRIPTION
## Summary
- normalize user text for search utilities
- short-circuit smalltalk intents via regex fastpath
- cover smalltalk fastpath with unit tests

## Testing
- `pytest tests/test_fastpath_smalltalk.py tests/test_intent_classifier.py`
- `pytest` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68acfdce9e5c832f8272c51da6cf131f