### PR TITLE
Flatten smalltalk intents

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -236,6 +236,10 @@ FAREWELL_RESPONSE = (
     "inicia una nueva conversación."
 )
 
+THANKS_RESPONSE = (
+    "¡De nada! Estoy aquí para ayudarte. ¿Necesitas algo más?"
+)
+
 # --- Variación de respuestas FAQ ---
 _RND = random.Random(os.getenv("ANSWER_SEED", "munbot"))
 
@@ -1334,6 +1338,7 @@ def orchestrate(
         "reclamo": "init_complaint",
         "saludo": "saludo",
         "despedida": "despedida",
+        "agradecimiento": "agradecimiento",
     }
     intent = intent_map.get(classification.get("intent"), "n/a")
 
@@ -1356,6 +1361,10 @@ def orchestrate(
         context_manager.clear_context(sid)
         delete_session(sid)
         return {"respuesta": FAREWELL_RESPONSE, "session_id": sid}
+
+    if intent == "agradecimiento":
+        context_manager.update_context(sid, user_input, THANKS_RESPONSE)
+        return {"respuesta": THANKS_RESPONSE, "session_id": sid}
 
     # --- Flujo de Consulta de Documentos (RAG) ---
     if intent == "ask_document":

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -606,8 +606,28 @@ async def tools_call(request: Request):
             return {"fragmentos": frags}
         elif tool == "doc-classify_intent_llm":
             texto = _get_texto(params)
-            intent = classify_intent_with_llm(texto, llama, mode='plain')
-            return {"intent": intent}
+            result = classify_intent_with_llm(texto, llama, mode="rich")
+            if isinstance(result, str):
+                flat = result
+                intent = result
+                sub_intent = None
+            else:
+                intent = result.get("intent")
+                sub_intent = result.get("sub_intent")
+                if intent == "faq" and sub_intent in {"saludo", "despedida", "agradecimiento"}:
+                    flat = sub_intent
+                else:
+                    flat = intent
+            logger.debug(
+                {
+                    "tool": "doc-classify_intent_llm",
+                    "mode": "rich->flat",
+                    "intent": intent,
+                    "sub_intent": sub_intent,
+                    "returned": flat,
+                }
+            )
+            return {"intent": flat}
         else:
             raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
     except ValidationError as ve:
@@ -642,8 +662,28 @@ async def tools_doc_generar_respuesta_llm(params: dict):
 @app.post("/tools/doc-classify_intent_llm", dependencies=[Depends(authenticate)])
 async def tools_doc_classify_intent_llm(params: dict):
     texto = _get_texto(params)
-    intent = classify_intent_with_llm(texto, llama, mode='plain')
-    return {"intent": intent}
+    result = classify_intent_with_llm(texto, llama, mode="rich")
+    if isinstance(result, str):
+        flat = result
+        intent = result
+        sub_intent = None
+    else:
+        intent = result.get("intent")
+        sub_intent = result.get("sub_intent")
+        if intent == "faq" and sub_intent in {"saludo", "despedida", "agradecimiento"}:
+            flat = sub_intent
+        else:
+            flat = intent
+    logger.debug(
+        {
+            "tool": "doc-classify_intent_llm",
+            "mode": "rich->flat",
+            "intent": intent,
+            "sub_intent": sub_intent,
+            "returned": flat,
+        }
+    )
+    return {"intent": flat}
 
 
 @app.post("/doc-buscar_fragmento_documento", dependencies=[Depends(authenticate)])

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -41,8 +41,14 @@ sys.modules["sentence_transformers"] = fake_st
 fake_ic = types.ModuleType("intent_classifier")
 fake_ic.__spec__ = importlib.machinery.ModuleSpec("intent_classifier", loader=None)
 
-def fake_classify_intent_with_llm(texto, llama):
-    return {"intent": "faq"}
+def fake_classify_intent_with_llm(texto, llama=None, mode=None):
+    mapping = {
+        "hola": {"intent": "faq", "sub_intent": "saludo"},
+        "adios": {"intent": "faq", "sub_intent": "despedida"},
+        "gracias": {"intent": "faq", "sub_intent": "agradecimiento"},
+        "permiso de circulación": {"intent": "documento"},
+    }
+    return mapping.get(texto, {"intent": "faq"})
 
 def fake_set_llm_client(client):
     pass
@@ -241,6 +247,35 @@ class TestGateway(unittest.TestCase):
         }
         resp = self.client.post("/tools/call", json=payload)
         self.assertEqual(resp.status_code, 200)
+
+    def test_doc_classify_intent_saludo(self):
+        resp = self.client.post(
+            "/tools/doc-classify_intent_llm", json={"texto": "hola"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("intent"), "saludo")
+
+    def test_doc_classify_intent_despedida(self):
+        resp = self.client.post(
+            "/tools/doc-classify_intent_llm", json={"texto": "adios"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("intent"), "despedida")
+
+    def test_doc_classify_intent_agradecimiento(self):
+        resp = self.client.post(
+            "/tools/doc-classify_intent_llm", json={"texto": "gracias"}
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("intent"), "agradecimiento")
+
+    def test_doc_classify_intent_regular(self):
+        resp = self.client.post(
+            "/tools/doc-classify_intent_llm",
+            json={"texto": "permiso de circulación"},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get("intent"), "documento")
 
 def test_doc_buscar_fragmento_documento_direct_call_and_threshold():
     """Calls rag.doc_buscar_fragmento_documento and checks parameter propagation."""

--- a/tests/test_farewell.py
+++ b/tests/test_farewell.py
@@ -26,9 +26,11 @@ def fake_embed(texts, batch_size=32):
 fake_embeddings.embed = fake_embed
 sys.modules['embeddings'] = fake_embeddings
 
-sys.path.insert(0, os.path.abspath('mcp-core'))
+package = types.ModuleType('mcp_core')
+package.__path__ = ['mcp-core']
+sys.modules['mcp_core'] = package
 
-spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+spec = importlib.util.spec_from_file_location('mcp_core.orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(orchestrator)
 os.environ.pop("PROMPTS_PATH", None)
@@ -36,6 +38,18 @@ os.environ.pop("PROMPTS_PATH", None)
 fake = fakeredis.FakeRedis()
 orchestrator.redis_client = fake
 orchestrator.context_manager.redis_client = fake
+
+def fake_classify(text, trace_id=None):
+    t = text.lower()
+    if "hola" in t:
+        return {"intent": "saludo"}
+    if "adios" in t:
+        return {"intent": "despedida"}
+    if "gracias" in t:
+        return {"intent": "agradecimiento"}
+    return {"intent": "faq"}
+
+orchestrator.llm_client.classify_intent = fake_classify
 
 client = TestClient(orchestrator.app)
 
@@ -49,3 +63,9 @@ def test_farewell_resets_context():
     assert r2.status_code == 200
     assert 'hasta luego' in r2.json()['respuesta'].lower()
     assert orchestrator.context_manager.get_context(sid) == {}
+
+
+def test_thanks_response():
+    r = client.post('/orchestrate', json={'pregunta': 'gracias'})
+    assert r.status_code == 200
+    assert 'de nada' in r.json()['respuesta'].lower()


### PR DESCRIPTION
## Summary
- Normalize `doc-classify_intent_llm` responses to return flat smalltalk intents and add debug logging
- Map new `agradecimiento` intent to a canned response in the orchestrator
- Cover smalltalk mapping with service and orchestrator tests

## Testing
- `pytest services/llm_docs-mcp/test_tools.py tests/test_fastpath_smalltalk.py tests/test_intent_classifier.py tests/test_farewell.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad02511b74832f9ecd204ae47faa38