### PR TITLE
feat: add smalltalk fallback to LLM intent classifier

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -33,7 +33,11 @@ from qdrant_utils import (
     filter_by_department_id,
 )
 import rag
-from intent_classifier import classify_intent_with_llm, set_llm_client
+from intent_classifier import (
+    classify_intent_with_llm,
+    set_llm_client,
+    flatten_for_orchestrator,
+)
 from pythonjsonlogger import jsonlogger
 
 # ==== Configuración ====
@@ -607,17 +611,9 @@ async def tools_call(request: Request):
         elif tool == "doc-classify_intent_llm":
             texto = _get_texto(params)
             result = classify_intent_with_llm(texto, llama, mode="rich")
-            if isinstance(result, str):
-                flat = result
-                intent = result
-                sub_intent = None
-            else:
-                intent = result.get("intent")
-                sub_intent = result.get("sub_intent")
-                if intent == "faq" and sub_intent in {"saludo", "despedida", "agradecimiento"}:
-                    flat = sub_intent
-                else:
-                    flat = intent
+            flat = flatten_for_orchestrator(result)
+            intent = result.get("intent") if isinstance(result, dict) else result
+            sub_intent = result.get("sub_intent") if isinstance(result, dict) else None
             logger.debug(
                 {
                     "tool": "doc-classify_intent_llm",
@@ -663,17 +659,9 @@ async def tools_doc_generar_respuesta_llm(params: dict):
 async def tools_doc_classify_intent_llm(params: dict):
     texto = _get_texto(params)
     result = classify_intent_with_llm(texto, llama, mode="rich")
-    if isinstance(result, str):
-        flat = result
-        intent = result
-        sub_intent = None
-    else:
-        intent = result.get("intent")
-        sub_intent = result.get("sub_intent")
-        if intent == "faq" and sub_intent in {"saludo", "despedida", "agradecimiento"}:
-            flat = sub_intent
-        else:
-            flat = intent
+    flat = flatten_for_orchestrator(result)
+    intent = result.get("intent") if isinstance(result, dict) else result
+    sub_intent = result.get("sub_intent") if isinstance(result, dict) else None
     logger.debug(
         {
             "tool": "doc-classify_intent_llm",

--- a/services/llm_docs-mcp/intent_classifier.py
+++ b/services/llm_docs-mcp/intent_classifier.py
@@ -11,7 +11,17 @@ from intent_engine import classify_intent_payload
 from text_utils import normalize_for_search
 
 
-_VALID = {"faq", "documento", "agenda", "reclamo", "tramite", "n/a"}
+LLM_INTENT_LABELS = [
+    "faq",
+    "documento",
+    "tramite",
+    "agenda",
+    "reclamo",
+    "saludo",
+    "despedida",
+    "agradecimiento",
+    "n/a",
+]
 
 # Compiled patterns for smalltalk fast-path
 SALUDO_PAT = re.compile(r"\b(hola|buen[oa]s(?:\s*(dias|tardes|noches))?|que tal|como estas)\b", re.I)
@@ -69,6 +79,32 @@ def fastpath_smalltalk(user_text: str):
     return None
 
 
+def build_llm_prompt(user_text: str) -> str:
+    labels = " | ".join(LLM_INTENT_LABELS)
+    return (
+        "Clasifica la consulta EXACTAMENTE en una de estas categorías:\n"
+        f"{labels}\n\n"
+        "Reglas:\n"
+        "- 'saludo', 'despedida' y 'agradecimiento' son smalltalk, p.ej. 'hola', 'adiós', 'gracias'.\n"
+        "- 'documento' y 'tramite' son consultas informativas sobre normativa/procesos.\n"
+        "- 'faq' es genérico y abarca preguntas frecuentes cuando no quede claro si es documento o trámite.\n"
+        "- 'agenda' para pedir hora; 'reclamo' para iniciar queja/formalizar denuncia.\n"
+        "- Si no encaja, responde 'n/a'.\n\n"
+        f"Texto del usuario:\n\"\"\"{user_text}\"\"\"\n"
+        "Devuelve solo la etiqueta, sin explicación."
+    )
+
+
+def classify_with_llm(user_text: str, llm: LlamaClient | None = None) -> dict:
+    client = llm or _llm()
+    label = (client.generate(build_llm_prompt(user_text), temperature=0) or "").strip().lower()
+    if label not in LLM_INTENT_LABELS:
+        label = "n/a"
+    if label in {"saludo", "despedida", "agradecimiento"}:
+        return {"intent": "faq", "sub_intent": label, "source": "llm"}
+    return {"intent": label, "sub_intent": None, "source": "llm"}
+
+
 def classify_intent_with_llm(user_input: str, llm: LlamaClient | None = None, mode: str | None = None):
     """Classify a user's intent using the RAG engine with an LLM fallback."""
 
@@ -89,21 +125,9 @@ def classify_intent_with_llm(user_input: str, llm: LlamaClient | None = None, mo
     # 1) IntentEngine primero (usa RAG + alias + tags)
     rich = classify_intent_payload(text)
 
-    # 2) Fallback: si el engine no está seguro, pedir SOLO la superclase al LLM
+    # 2) Fallback: si el engine no está seguro, usar LLM
     if rich.get("intent") == "n/a":
-        client = llm or _llm()
-        prompt = (
-            "Clasifica la consulta EXACTAMENTE en una de estas categorías:\n"
-            "faq | documento | agenda | reclamo | tramite | n/a\n\n"
-            "Reglas:\n"
-            "- Responde SOLO con una palabra del listado.\n"
-            "- No inventes categorías.\n\n"
-            f"Consulta: {text}\n"
-            "Etiqueta:"
-        )
-        guess = (client.generate(prompt, temperature=0) or "").strip().lower()
-        if guess in _VALID:
-            rich["intent"] = guess
+        rich.update(classify_with_llm(text, llm))
 
     # 3) Normalización leve de slots por compat (si tu heurística añade 'horario'/'vigencia')
     if rich.get("slot"):
@@ -139,4 +163,13 @@ def classify_reclamo_response(text: str) -> str:
     if t.startswith("no") or " no" in t:
         return "negative"
     return "unknown"
+
+
+def flatten_for_orchestrator(pred: dict | str) -> str:
+    if isinstance(pred, str):
+        return pred
+    intent, sub = pred.get("intent"), pred.get("sub_intent")
+    if intent == "faq" and sub in {"saludo", "despedida", "agradecimiento"}:
+        return sub
+    return intent or "n/a"
 

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 os.environ["ALLOWED_IPS"] = "testclient,127.0.0.1"
 os.environ["LLM_DOCS_API_KEY"] = "test-key"
+os.environ["LLAMA_MOCK"] = "1"
 
 # Stub llama_cpp to avoid heavy dependency in tests
 fake_llama = types.ModuleType("llama_cpp")
@@ -53,8 +54,17 @@ def fake_classify_intent_with_llm(texto, llama=None, mode=None):
 def fake_set_llm_client(client):
     pass
 
+def fake_flatten_for_orchestrator(pred):
+    if isinstance(pred, dict):
+        sub = pred.get("sub_intent")
+        if pred.get("intent") == "faq" and sub in {"saludo", "despedida", "agradecimiento"}:
+            return sub
+        return pred.get("intent")
+    return pred
+
 fake_ic.classify_intent_with_llm = fake_classify_intent_with_llm
 fake_ic.set_llm_client = fake_set_llm_client
+fake_ic.flatten_for_orchestrator = fake_flatten_for_orchestrator
 sys.modules["intent_classifier"] = fake_ic
 
 # Patch httpx.Client to ignore deprecated 'app' parameter used by Starlette TestClient

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -15,7 +15,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
 sys.modules.pop("intent_classifier", None)
 
 # Ahora las importaciones deberían funcionar
-from intent_classifier import classify_reclamo_response, classify_intent_with_llm
+from intent_classifier import (
+    classify_reclamo_response,
+    classify_intent_with_llm,
+    flatten_for_orchestrator,
+)
 
 # --- Pruebas para la lógica de clasificación de respuestas de reclamos ---
 
@@ -55,6 +59,8 @@ class MockIntentEngine:
             return {"intent": "reclamo"}
         if "permiso" in text:
             return {"intent": "tramite"}
+        if "horario" in text:
+            return {"intent": "documento"}
         if "documento" in text:
             return {"intent": "documento"}
         if "información" in text:
@@ -84,3 +90,21 @@ def test_classify_main_intent_basic(user_input, expected_intent):
     assert result.get("intent") == expected_intent.get("intent")
     if expected_intent.get("sub_intent"):
         assert result.get("sub_intent") == expected_intent.get("sub_intent")
+
+
+@pytest.mark.parametrize(
+    "user_input, expected_label",
+    [
+        ("hola", "saludo"),
+        ("adiós", "despedida"),
+        ("gracias", "agradecimiento"),
+        ("permiso de circulación", "tramite"),
+        ("horario comercio", "documento"),
+        ("quiero agendar una hora", "agenda"),
+        ("quiero poner un reclamo", "reclamo"),
+        ("ruido", "n/a"),
+    ],
+)
+def test_flatten_for_orchestrator_outputs(user_input, expected_label):
+    result = classify_intent_with_llm(user_input)
+    assert flatten_for_orchestrator(result) == expected_label


### PR DESCRIPTION
## Summary
- add smalltalk labels and unified prompt for LLM intent classifier
- flatten smalltalk intents before returning to orchestrator
- extend tests to cover smalltalk and intent flattening

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest tests/test_fastpath_smalltalk.py tests/test_intent_classifier.py -q`
- `pytest services/llm_docs-mcp/test_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad1a7d2448832fa336d3a240199c82