### PR TITLE
Propagate sub-intent from LLM classifier

### DIFF
--- a/mcp-core/clients/llm_docs.py
+++ b/mcp-core/clients/llm_docs.py
@@ -49,7 +49,7 @@ class LlmDocsClient:
 
     # --- Alto nivel ---
     def classify_intent(self, texto: str, trace_id: Optional[str] = None) -> dict:
-        """Clasifica la intención y devuelve un dict con intent y entities."""
+        """Clasifica la intención del usuario y preserva sub_intent cuando exista."""
         resp = self.tools_call("doc-classify_intent_llm", {"texto": texto}, trace_id)
         raw_intent = resp.get("intent")
         sub_intent = resp.get("sub_intent")
@@ -64,7 +64,7 @@ class LlmDocsClient:
             intent = sub_intent
 
         entities = resp.get("entities") or {}
-        return {"intent": intent, "entities": entities}
+        return {"intent": intent, "sub_intent": sub_intent, "entities": entities}
 
     def doc_generar_respuesta_llm(self, pregunta: str, trace_id: Optional[str] = None, **kwargs) -> dict:
         params = {"pregunta": pregunta} | kwargs

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -623,7 +623,7 @@ async def tools_call(request: Request):
                     "returned": flat,
                 }
             )
-            return {"intent": flat}
+            return {"intent": flat, "sub_intent": sub_intent}
         else:
             raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
     except ValidationError as ve:
@@ -671,7 +671,7 @@ async def tools_doc_classify_intent_llm(params: dict):
             "returned": flat,
         }
     )
-    return {"intent": flat}
+    return {"intent": flat, "sub_intent": sub_intent}
 
 
 @app.post("/doc-buscar_fragmento_documento", dependencies=[Depends(authenticate)])

--- a/tests/test_llm_docs_client.py
+++ b/tests/test_llm_docs_client.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+# Add clients path
+sys.path.insert(0, os.path.abspath('mcp-core/clients'))
+from llm_docs import LlmDocsClient
+
+def test_classify_intent_returns_subintent(monkeypatch):
+    client = LlmDocsClient(base_url='http://dummy')
+    def fake_tools_call(tool, params, trace_id=None):
+        assert tool == 'doc-classify_intent_llm'
+        return {'intent': 'saludo', 'sub_intent': 'saludo'}
+    monkeypatch.setattr(client, 'tools_call', fake_tools_call)
+    result = client.classify_intent('hola')
+    assert result['intent'] == 'saludo'
+    assert result['sub_intent'] == 'saludo'


### PR DESCRIPTION
## Summary
- Include `sub_intent` in `doc-classify_intent_llm` responses so orchestrator can see smalltalk types
- Preserve `sub_intent` in `LlmDocsClient.classify_intent`
- Test that client forwards sub-intent from the service

## Testing
- `pytest tests/test_fastpath_smalltalk.py tests/test_intent_classifier.py tests/test_llm_docs_client.py`
- `pytest` *(fails: ImportError while importing orchestrator in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68adcadeaf44832f896339c83c878390