### PR TITLE
feat: document RAG collections and add category tests

### DIFF
--- a/gateways/evolution-api/.env.example
+++ b/gateways/evolution-api/.env.example
@@ -7,3 +7,8 @@ MCP_URL=http://mcp-core:5000/orchestrate
 # Puerto del servidor Express/WebSocket (opcional)
 PORT=8080
 HF_API_TOKEN=<YOUR_TOKEN_HERE>
+# Configuración opcional para la selección de colección según la categoría
+RAG_COLLECTION_FAQ=munbot_faq
+RAG_COLLECTION_TRAMITES=munbot_tramites
+RAG_COLLECTION_NORMATIVA=munbot_normativa
+RAG_CATEGORY_AWARE=0

--- a/gateways/evolution-manager/.env.example
+++ b/gateways/evolution-manager/.env.example
@@ -7,3 +7,8 @@ VITE_API_URL=http://localhost:9615
 # Puerto del frontend (opcional, depende de tu configuración de Docker/Vite)
 VITE_PORT=3000
 HF_API_TOKEN=<YOUR_TOKEN_HERE>
+# Configuración opcional para la selección de colección según la categoría
+RAG_COLLECTION_FAQ=munbot_faq
+RAG_COLLECTION_TRAMITES=munbot_tramites
+RAG_COLLECTION_NORMATIVA=munbot_normativa
+RAG_CATEGORY_AWARE=0

--- a/services/llm_docs-mcp/README.md
+++ b/services/llm_docs-mcp/README.md
@@ -6,6 +6,8 @@ Servicio de búsqueda y generación de respuestas basado en documentos usando Qd
 
 - `QDRANT_SIMILARITY_THRESHOLD` (por defecto `0.5`): umbral de similitud para aceptar el mejor resultado de Qdrant. Ajusta este valor entre `0.45` y `0.6` según necesites mayor recall o mayor precisión.
 - `LLM_MAX_NEW_TOKENS` (por defecto `150`): cantidad máxima de tokens que generará el modelo al responder.
+- `RAG_COLLECTION_FAQ`, `RAG_COLLECTION_TRAMITES`, `RAG_COLLECTION_NORMATIVA`: nombres de las colecciones en Qdrant que se usarán para responder preguntas de tipo FAQ, trámites y normativa respectivamente.
+- `RAG_CATEGORY_AWARE` (`0` o `1`): si se activa (`1`), el servicio seleccionará automáticamente la colección y el prompt según la categoría indicada en la consulta (`categoria`).
 
 Configura estas variables en tu entorno o en `compose/.env` según tus necesidades.
 

--- a/services/llm_docs-mcp/config.env.example
+++ b/services/llm_docs-mcp/config.env.example
@@ -13,9 +13,11 @@ DOCS_DIR=/app/documents
 QDRANT_HOST=qdrant
 QDRANT_PORT=6333
 QDRANT_COLLECTION=munbot_docs
+# Colecciones específicas por categoría
 RAG_COLLECTION_FAQ=munbot_faq
 RAG_COLLECTION_TRAMITES=munbot_tramites
 RAG_COLLECTION_NORMATIVA=munbot_normativa
+# Habilita la selección automática de colección según la categoría de la consulta (0 o 1)
 RAG_CATEGORY_AWARE=0
 EMBEDDINGS_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
 EMBEDDINGS_DIM=384

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -303,5 +303,60 @@ def test_doc_buscar_fragmento_documento_direct_call_and_threshold():
     mock_of.assert_called_once_with(consulta="hola", k=5, tema_especifico="doc.txt")
     assert res == [{"texto": "a", "rerank_score": 0.9}]
 
+
+def _setup_category_env(monkeypatch):
+    monkeypatch.setenv("RAG_CATEGORY_AWARE", "1")
+    monkeypatch.setattr(rag, "RAG_CATEGORY_AWARE", True)
+    monkeypatch.setenv("RAG_COLLECTION_FAQ", "faq_coll")
+    monkeypatch.setattr(rag, "RAG_COLLECTION_FAQ", "faq_coll")
+    monkeypatch.setenv("RAG_COLLECTION_TRAMITES", "tram_coll")
+    monkeypatch.setattr(rag, "RAG_COLLECTION_TRAMITES", "tram_coll")
+    monkeypatch.setenv("RAG_COLLECTION_NORMATIVA", "norm_coll")
+    monkeypatch.setattr(rag, "RAG_COLLECTION_NORMATIVA", "norm_coll")
+    monkeypatch.setenv("PROMPT_FAQ", "faq_prompt.txt")
+    monkeypatch.setattr(rag, "PROMPT_FAQ", "faq_prompt.txt")
+    monkeypatch.setenv("PROMPT_TRAMITE", "tram_prompt.txt")
+    monkeypatch.setattr(rag, "PROMPT_TRAMITE", "tram_prompt.txt")
+    monkeypatch.setenv("PROMPT_DOCUMENTO", "doc_prompt.txt")
+    monkeypatch.setattr(rag, "PROMPT_DOCUMENTO", "doc_prompt.txt")
+
+
+def _run_categoria_test(monkeypatch, categoria, expected_collection, expected_prompt):
+    _setup_category_env(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(rag, "crear_plan", lambda pregunta, dominios: [pregunta])
+
+    def fake_obtener_fragmentos(consulta, k=3, tema_especifico=None, tramite=None,
+                                departamento=None, dominios=None, collection_name=None):
+        captured["collection"] = collection_name
+        return [{"texto": "x", "rerank_score": 1.0}]
+
+    monkeypatch.setattr(rag, "obtener_fragmentos", fake_obtener_fragmentos)
+
+    def fake_load_prompt(name):
+        captured["prompt"] = name
+        return "CTX {{contexto}}\nQ {{pregunta}}"
+
+    monkeypatch.setattr(rag, "load_prompt", fake_load_prompt)
+    monkeypatch.setattr(rag.lama, "generate", lambda prompt: "resp")
+    monkeypatch.setattr(rag, "verificar_atribucion", lambda r, c: True)
+
+    rag.generar_respuesta("hola", categoria=categoria)
+
+    assert captured["collection"] == expected_collection
+    assert captured["prompt"] == expected_prompt
+
+
+def test_generar_respuesta_categoria_faq(monkeypatch):
+    _run_categoria_test(monkeypatch, "faq", "faq_coll", "faq_prompt.txt")
+
+
+def test_generar_respuesta_categoria_tramite(monkeypatch):
+    _run_categoria_test(monkeypatch, "tramite", "tram_coll", "tram_prompt.txt")
+
+
+def test_generar_respuesta_categoria_normativa(monkeypatch):
+    _run_categoria_test(monkeypatch, "normativa", "norm_coll", "doc_prompt.txt")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_document_rag.py
+++ b/tests/test_document_rag.py
@@ -26,7 +26,10 @@ fake_embeddings.embed = fake_embed
 sys.modules['embeddings'] = fake_embeddings
 
 sys.path.insert(0, os.path.abspath('mcp-core'))
-spec = importlib.util.spec_from_file_location('orchestrator', os.path.join('mcp-core','orchestrator.py'))
+mcp_core = types.ModuleType('mcp_core')
+mcp_core.__path__ = [os.path.abspath('mcp-core')]
+sys.modules['mcp_core'] = mcp_core
+spec = importlib.util.spec_from_file_location('mcp_core.orchestrator', os.path.join('mcp-core','orchestrator.py'))
 orchestrator = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(orchestrator)
 
@@ -73,6 +76,32 @@ def test_short_question_expands(monkeypatch):
     orchestrator.orchestrate('y el costo?', session_id=sid)
     assert calls[0]['documento'] == 'Permiso de Circulacion'
     assert calls[0]['pregunta'].endswith('del trámite Permiso de Circulacion')
+
+
+def test_categoria_propagates_collection(monkeypatch):
+    os.environ['RAG_COLLECTION_FAQ'] = 'faq_coll'
+    os.environ['RAG_COLLECTION_TRAMITES'] = 'tram_coll'
+    os.environ['RAG_COLLECTION_NORMATIVA'] = 'norm_coll'
+
+    captured = {}
+
+    def fake_call(tool, params, trace_id=None):
+        captured['params'] = params.copy()
+        cat = params.get('categoria')
+        if cat == 'faq':
+            captured['collection'] = os.environ['RAG_COLLECTION_FAQ']
+        elif cat in {'tramite', 'tramites', 'trámite', 'trámites'}:
+            captured['collection'] = os.environ['RAG_COLLECTION_TRAMITES']
+        else:
+            captured['collection'] = os.environ['RAG_COLLECTION_NORMATIVA']
+        return {'respuesta': 'ok'}
+
+    monkeypatch.setattr(orchestrator, 'call_tool_microservice', fake_call)
+
+    orchestrator.handle_document_query('sid', 'pregunta', {}, [], 'tramites')
+
+    assert captured['params']['categoria'] == 'tramites'
+    assert captured['collection'] == 'tram_coll'
 
 
 def test_generic_doc_query_prompts_specific(monkeypatch):

--- a/tests/test_llm_docs_client.py
+++ b/tests/test_llm_docs_client.py
@@ -15,3 +15,32 @@ def test_classify_intent_returns_subintent(monkeypatch):
     result = client.classify_intent('hola')
     assert result['intent'] == 'saludo'
     assert result['sub_intent'] == 'saludo'
+
+
+def test_doc_generar_respuesta_llm_categoria(monkeypatch):
+    os.environ['RAG_COLLECTION_FAQ'] = 'faq_coll'
+    os.environ['RAG_COLLECTION_TRAMITES'] = 'tram_coll'
+    os.environ['RAG_COLLECTION_NORMATIVA'] = 'norm_coll'
+
+    client = LlmDocsClient(base_url='http://dummy')
+    captured = {}
+
+    def fake_tools_call(tool, params, trace_id=None):
+        captured['tool'] = tool
+        captured['params'] = params
+        cat = params.get('categoria')
+        if cat == 'faq':
+            captured['collection'] = os.environ['RAG_COLLECTION_FAQ']
+        elif cat in {'tramite', 'tramites', 'trámite', 'trámites'}:
+            captured['collection'] = os.environ['RAG_COLLECTION_TRAMITES']
+        else:
+            captured['collection'] = os.environ['RAG_COLLECTION_NORMATIVA']
+        return {'respuesta': 'ok'}
+
+    monkeypatch.setattr(client, 'tools_call', fake_tools_call)
+
+    client.doc_generar_respuesta_llm('pregunta', categoria='faq')
+
+    assert captured['tool'] == 'doc-generar_respuesta_llm'
+    assert captured['params']['categoria'] == 'faq'
+    assert captured['collection'] == 'faq_coll'


### PR DESCRIPTION
## Summary
- document RAG_COLLECTION_* and RAG_CATEGORY_AWARE in README and example env files
- add propagation tests for `categoria` in orchestrator and client
- cover category-specific prompt and collection selection in service tests

## Testing
- `pytest tests/test_document_rag.py::test_categoria_propagates_collection tests/test_llm_docs_client.py::test_doc_generar_respuesta_llm_categoria services/llm_docs-mcp/test_tools.py::test_generar_respuesta_categoria_faq services/llm_docs-mcp/test_tools.py::test_generar_respuesta_categoria_tramite services/llm_docs-mcp/test_tools.py::test_generar_respuesta_categoria_normativa`
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf629b6ba8832f8ddd1836a68b979e