### PR TITLE
feat: track category in metrics and RAG logs

### DIFF
--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -168,7 +168,7 @@ PROM_REGISTRY = CollectorRegistry()
 REQUEST_COUNTER = Counter(
     "munbot_requests_total",
     "Número de peticiones procesadas",
-    ["intent"],
+    ["intent", "categoria"],
     registry=PROM_REGISTRY,
 )
 FALLBACK_COUNTER = Counter(
@@ -184,7 +184,7 @@ HUMAN_ESCALATION_COUNTER = Counter(
 ERROR_COUNTER = Counter(
     "mcp_microservice_errors_total",
     "Errores al invocar microservicios",
-    ["intent"],
+    ["intent", "categoria"],
     registry=PROM_REGISTRY,
 )
 CACHE_HIT_COUNTER = Counter(
@@ -728,13 +728,19 @@ def handle_turn(session_id: str, user_input: str) -> Dict[str, Any]:
     return call_tool_microservice("doc-search", {"pregunta": user_input})
 
 
-def handle_service_error(resp: Dict[str, Any], intent: str, trace_id: str | None = None) -> Optional[Dict[str, str]]:
+def handle_service_error(
+    resp: Dict[str, Any],
+    intent: str,
+    trace_id: str | None = None,
+    categoria: str | None = None,
+) -> Optional[Dict[str, str]]:
     """Check microservice response and return friendly message on error."""
     if resp.get("error"):
         logger.error(
-            f"Microservice error: {resp['error']}", extra={"trace_id": trace_id}
+            f"Microservice error: {resp['error']}",
+            extra={"trace_id": trace_id, "categoria": categoria},
         )
-        ERROR_COUNTER.labels(intent=intent).inc()
+        ERROR_COUNTER.labels(intent=intent, categoria=categoria or "unknown").inc()
         return {"texto": "Ocurrió un problema al consultar nuestros servicios. Por favor, intenta más tarde."}
     return None
 
@@ -1485,7 +1491,7 @@ def orchestrate(
         extra={"trace_id": sid, "intent_norm": categoria},
     )
     _log_router("intent_decided", intent=intent, intent_norm=categoria)
-    REQUEST_COUNTER.labels(intent=intent).inc()
+    REQUEST_COUNTER.labels(intent=intent, categoria=categoria).inc()
 
     # --- 2. ENRUTAMIENTO BASADO EN INTENCIÓN ---
     if intent in {"saludo", "despedida", "agradecimiento"}:
@@ -1574,9 +1580,26 @@ def handle_document_query(
     response = call_tool_microservice("doc-generar_respuesta_llm", tool_params, trace_id=session_id)
 
     # Manejar errores del servicio
-    error_response = handle_service_error(response, "doc-generar_respuesta_llm", trace_id=session_id)
+    error_response = handle_service_error(
+        response, "doc-generar_respuesta_llm", trace_id=session_id, categoria=intent_type
+    )
     if error_response:
         return {"respuesta": error_response["texto"], "session_id": session_id}
+
+    # Registrar métricas del servicio RAG
+    hit = response.get("hit")
+    if hit is None:
+        hit = bool(response.get("respuesta") or response.get("candidates"))
+    logger.info(
+        "[RAG] Respuesta recibida",
+        extra={
+            "trace_id": session_id,
+            "categoria": intent_type,
+            "collection": response.get("collection"),
+            "top_k": response.get("top_k"),
+            "hit": hit,
+        },
+    )
     # 1) Si llm_docs devuelve un ítem enriquecido (opcional futuro)
     item = response.get("item") or {}
     if item:

--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -172,7 +172,7 @@ HUMAN_ESCALATION_COUNTER = Counter(
 ERROR_COUNTER = Counter(
     "munbot_errors_total",
     "Número de errores de microservicios",
-    ["intent"],
+    ["intent", "categoria"],
     registry=PROM_REGISTRY,
 )
 
@@ -397,6 +397,8 @@ def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:
     pregunta = params.get("pregunta", "")
     categoria = params.get("categoria")
     REQUEST_COUNTER.labels(intent="doc-generar_respuesta_llm", categoria=categoria or "unknown").inc()
+    collection_name, _ = rag._category_config(categoria)
+    top_k = params.get("top_k", 3)
     if not pregunta:
         return {"respuesta": "", "referencias": [], "no_results": True}
 
@@ -414,7 +416,7 @@ def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:
             f"RAG generation failed: {e}",
             extra={"trace_id": trace_id, "categoria": categoria},
         )
-        ERROR_COUNTER.labels(intent="doc-generar_respuesta_llm").inc()
+        ERROR_COUNTER.labels(intent="doc-generar_respuesta_llm", categoria=categoria or "unknown").inc()
         return {"respuesta": "", "referencias": [], "no_results": True}
 
     referencias: list[str] = []
@@ -426,15 +428,23 @@ def generar_respuesta_llm(params: dict, trace_id: str = "unknown") -> dict:
         elif isinstance(fuente, str):
             referencias.append(fuente)
 
+    hit = bool(result.get("respuesta"))
     logger.info(
         "Respuesta generada",
-        extra={"trace_id": trace_id, "categoria": categoria, "fragments": referencias},
+        extra={
+            "trace_id": trace_id,
+            "categoria": categoria,
+            "collection": collection_name,
+            "top_k": top_k,
+            "hit": hit,
+            "fragments": referencias,
+        },
     )
 
     return {
         "respuesta": result.get("respuesta", ""),
         "referencias": list(set(referencias)),
-        "no_results": not bool(result.get("respuesta")),
+        "no_results": not hit,
     }
 
 # ==== MCP Endpoints ====


### PR DESCRIPTION
## Summary
- include `categoria` label on request and error metrics
- log RAG `categoria`, collection, top_k and hit for orchestrator and gateway
- propagate category to service-error metrics

## Testing
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6518ee34832fb3f971e491241c3d