### PR TITLE
feat: add RAG selection feature flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ RAG_CATEGORY_AWARE=0
 # Número máximo de llamadas a herramientas permitidas al agente
 AGENT_MAX_TOOL_CALLS=2
 
+# Modo de selección de RAG por categoría: collection | filter
+RAG_SELECTION_MODE=collection
+# Campo de metadato a usar cuando RAG_SELECTION_MODE=filter
+RAG_FILTER_FIELD=tipo
+
 # Colección RAG para preguntas frecuentes
 RAG_COLLECTION_FAQ=faq
 


### PR DESCRIPTION
## Summary
- add environment flags to control RAG selection mode

## Testing
- `pytest -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c061459e64832fb6c6eaedbc711f8e