### PR TITLE
feat: add agent mode handling

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -586,8 +586,14 @@ async def tools_call(request: Request):
     trace_id = "unknown"
     try:
         req = await request.json()
+        if AGENT_MODE and "messages" in req:
+            return await agent_mode(req)
         trace_id = req.get("trace_id", "unknown")
         tool = req.get("tool")
+        if not tool:
+            return JSONResponse(
+                {"error": "missing 'tool' or 'messages'"}, status_code=400
+            )
         params = req.get("params", {})
         categoria = params.get("categoria", "unknown")
         REQUEST_COUNTER.labels(intent=tool, categoria=categoria).inc()


### PR DESCRIPTION
## Summary
- delegate message handling to agent mode when available in tools endpoint
- add clearer error message when neither `tool` nor `messages` provided

## Testing
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c078548760832fa7c3c914c38c4b12