### PR TITLE
Add tool call parsing and parameter validation

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -41,6 +41,10 @@ from intent_classifier import (
 from pythonjsonlogger import jsonlogger
 
 
+JSON_CALL_RE = re.compile(r'\{[\s\S]*"call"[\s\S]*\}', re.MULTILINE)
+DSL_CALL_RE  = re.compile(r'<CALL\s+([\w\-.\/]+)\s*(.*?)>', re.DOTALL)
+
+
 def _getenv_int(name: str, default: int) -> int:
     try:
         return int(os.getenv(name, str(default)).strip())
@@ -79,6 +83,64 @@ TOOLS = {
         "handler": "handle_complaint_handover",
     },
 }
+
+def try_parse_call(text: str):
+    """Detecta intentos de llamada de herramientas en formato JSON o DSL.
+
+    Retorna una tupla ``(tool, params)`` si se encuentra una llamada válida,
+    en caso contrario ``None``.
+    """
+    if not text:
+        return None
+    text = text.strip()
+
+    m = JSON_CALL_RE.search(text)
+    if m:
+        try:
+            data = json.loads(m.group())
+        except Exception:
+            data = None
+        if isinstance(data, dict):
+            call = data.get("call")
+            if isinstance(call, dict):
+                tool = call.get("tool") or call.get("name")
+                params = call.get("params") or call.get("arguments") or {}
+                if isinstance(tool, str):
+                    return tool, params if isinstance(params, dict) else {}
+
+    m = DSL_CALL_RE.search(text)
+    if m:
+        tool = m.group(1)
+        args = m.group(2).strip()
+        params: dict = {}
+        if args:
+            try:
+                params = json.loads(args)
+            except Exception:
+                for k, v in re.findall(r'(\w+)="([^"]*)"', args):
+                    params[k] = v
+        return tool, params
+
+    return None
+
+
+def validate_params(tool_name: str, params: dict) -> None:
+    """Valida tipos y presencia de parámetros obligatorios según ``TOOLS``."""
+    schema = TOOLS.get(tool_name, {}).get("schema", {}) or {}
+    for param, spec in schema.items():
+        if isinstance(spec, tuple):
+            expected_type, _default = spec
+            required = False
+        else:
+            expected_type = spec
+            required = True
+        if required and param not in params:
+            raise HTTPException(status_code=400, detail=f"Falta parámetro requerido: {param}")
+        if param in params and params[param] is not None and not isinstance(params[param], expected_type):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Parámetro '{param}' debe ser de tipo {expected_type.__name__}",
+            )
 
 _logger = logging.getLogger("llm_docs_mcp")
 
@@ -659,6 +721,7 @@ async def tools_call(request: Request):
                 {"error": "missing 'tool' or 'messages'"}, status_code=400
             )
         params = req.get("params", {})
+        validate_params(tool, params)
         categoria = params.get("categoria", "unknown")
         REQUEST_COUNTER.labels(intent=tool, categoria=categoria).inc()
         faq_context = params.get("faq_context")

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -5,6 +5,8 @@ import unittest
 import importlib.machinery
 from fastapi.testclient import TestClient
 from unittest.mock import patch
+import pytest
+from fastapi import HTTPException
 
 os.environ["ALLOWED_IPS"] = "testclient,127.0.0.1"
 os.environ["LLM_DOCS_API_KEY"] = "test-key"
@@ -286,6 +288,27 @@ class TestGateway(unittest.TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json().get("intent"), "documento")
+
+def test_try_parse_call_json():
+    from gateway import try_parse_call
+
+    texto = '{"call": {"tool": "doc-generar_respuesta_llm", "params": {"query": "hola"}}}'
+    assert try_parse_call(texto) == ("doc-generar_respuesta_llm", {"query": "hola"})
+
+
+def test_try_parse_call_dsl():
+    from gateway import try_parse_call
+
+    texto = '<CALL doc-generar_respuesta_llm {"query": "hola"}>'
+    assert try_parse_call(texto) == ("doc-generar_respuesta_llm", {"query": "hola"})
+
+
+def test_validate_params():
+    from gateway import validate_params
+
+    validate_params("doc-generar_respuesta_llm", {"query": "hola"})
+    with pytest.raises(HTTPException):
+        validate_params("doc-generar_respuesta_llm", {})
 
 def test_doc_buscar_fragmento_documento_direct_call_and_threshold():
     """Calls rag.doc_buscar_fragmento_documento and checks parameter propagation."""


### PR DESCRIPTION
## Summary
- add regex patterns and helpers to parse tool calls from JSON or DSL
- validate tool call parameters against schema definitions
- cover new parsing and validation utilities with tests

## Testing
- `pytest services/llm_docs-mcp/test_tools.py -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c080f9eff4832f88969bab01ecb298