### PR TITLE
Add handlers for scheduler and complaint tools

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -76,10 +76,12 @@ TOOLS = {
     "scheduler-init": {
         "desc": "Entrega control al flujo de agenda (orquestador)",
         "schema": {},
+        "handler": "handle_scheduler_handover",
     },
     "complaint-init": {
         "desc": "Entrega control al flujo de reclamos (orquestador)",
         "schema": {},
+        "handler": "handle_complaint_handover",
     },
 }
 


### PR DESCRIPTION
## Summary
- add handler references for scheduler and complaint handover tools in llm_docs gateway

## Testing
- `pytest services/llm_docs-mcp -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09e54dc68832f9729cd68f723fa37