### PR TITLE
Define scheduler and complaint handover handlers

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -756,11 +756,11 @@ async def handle_rag_call(params, hints):
     return await generar_respuesta_llm(query, top_k=top_k, categoria=categoria)
 
 
-async def handle_scheduler_handover(params, hints):
+async def handle_scheduler_handover(params: dict, hints: dict):
     return {"type": "handover", "flow": "scheduler"}
 
 
-async def handle_complaint_handover(params, hints):
+async def handle_complaint_handover(params: dict, hints: dict):
     return {"type": "handover", "flow": "complaint"}
 
 


### PR DESCRIPTION
## Summary
- specify handover handlers for scheduler and complaint flows with type hints

## Testing
- `pytest -q` (fails: ImportError attempting relative import in mcp-core tests)

------
https://chatgpt.com/codex/tasks/task_e_68c0a1c4738c832facb2c0453a83791e