### PR TITLE
log handover in agent mode

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -875,10 +875,15 @@ async def agent_mode(req: dict):
             )
 
             if isinstance(result, dict) and result.get("type") == "handover":
-                duration_ms = int((time.time() - start_time) * 1000)
+                dt = int((time.time() - start_time) * 1000)
+                _logger.info(
+                    "agent.handover flow=%s duration_ms=%s",
+                    result.get("flow"),
+                    dt,
+                )
                 logger.info(
                     "agent.handover",
-                    extra={"trace_id": trace_id, "duration_ms": duration_ms},
+                    extra={"trace_id": trace_id, "duration_ms": dt},
                 )
                 return result
 


### PR DESCRIPTION
## Summary
- log handover event in agent-mode tool calls

## Testing
- `pytest` *(fails: 9 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a291b1c0832f85c84822da338df9