### PR TITLE
Add scheduler and complaint handover tools

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -1016,6 +1016,10 @@ async def tools_call(request: Request):
                 }
             )
             return {"intent": flat, "sub_intent": sub_intent}
+        elif tool == "scheduler-init":
+            return {"type": "handover", "flow": "scheduler"}
+        elif tool == "complaint-init":
+            return {"type": "handover", "flow": "complaint"}
         else:
             raise HTTPException(status_code=400, detail=f"Herramienta desconocida: {tool}")
     except ValidationError as ve:

--- a/services/llm_docs-mcp/test_tools.py
+++ b/services/llm_docs-mcp/test_tools.py
@@ -264,6 +264,18 @@ class TestGateway(unittest.TestCase):
         resp = self.client.post("/tools/call", json=payload)
         self.assertEqual(resp.status_code, 200)
 
+    def test_scheduler_init_tool(self):
+        payload = {"tool": "scheduler-init", "params": {}}
+        resp = self.client.post("/tools/call", json=payload)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"type": "handover", "flow": "scheduler"})
+
+    def test_complaint_init_tool(self):
+        payload = {"tool": "complaint-init", "params": {}}
+        resp = self.client.post("/tools/call", json=payload)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"type": "handover", "flow": "complaint"})
+
     def test_doc_classify_intent_saludo(self):
         resp = self.client.post(
             "/tools/doc-classify_intent_llm", json={"texto": "hola"}


### PR DESCRIPTION
## Summary
- handle `scheduler-init` and `complaint-init` in tools_call
- cover handover flows with new tests

## Testing
- `pytest services/llm_docs-mcp/test_tools.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1dc627b28832f9e88cded2feddc70