### PR TITLE
Check service health before handover

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -8,6 +8,7 @@ import time
 import re
 import ipaddress
 import requests
+import httpx
 import asyncio
 import inspect
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
@@ -168,6 +169,9 @@ LLM_GENERATION_TIMEOUT = int(os.getenv("LLM_GENERATION_TIMEOUT", "60"))
 QDRANT_SIMILARITY_THRESHOLD = float(os.getenv("QDRANT_SIMILARITY_THRESHOLD", 0.5))
 # Umbral de alta confianza para los resultados de Qdrant
 HIGH_CONFIDENCE_THRESHOLD = float(os.getenv("HIGH_CONFIDENCE_THRESHOLD", 0.6))
+
+SCHEDULER_HEALTH_URL = os.getenv("SCHEDULER_HEALTH_URL")
+COMPLAINTS_HEALTH_URL = os.getenv("COMPLAINTS_HEALTH_URL")
 
 # ==== Prompts por defecto ====
 PROMPT_FAQ = (
@@ -786,10 +790,24 @@ async def handle_rag_call(params, hints):
 
 
 async def handle_scheduler_handover(params: dict, hints: dict):
+    if SCHEDULER_HEALTH_URL:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(SCHEDULER_HEALTH_URL)
+                response.raise_for_status()
+        except Exception:
+            logger.warning("scheduler health check failed")
     return {"type": "handover", "flow": "scheduler"}
 
 
 async def handle_complaint_handover(params: dict, hints: dict):
+    if COMPLAINTS_HEALTH_URL:
+        try:
+            async with httpx.AsyncClient(timeout=2.0) as client:
+                response = await client.get(COMPLAINTS_HEALTH_URL)
+                response.raise_for_status()
+        except Exception:
+            logger.warning("complaints health check failed")
     return {"type": "handover", "flow": "complaint"}
 
 

--- a/services/llm_docs-mcp/requirements.txt
+++ b/services/llm_docs-mcp/requirements.txt
@@ -4,6 +4,7 @@ scikit-learn>=0.24.2
 prometheus_client>=0.16.0
 python-json-logger
 requests>=2.25.1
+httpx>=0.27.0
 
 # LLM, RAG & Vector DB
 llama-cpp-python>=0.2.11 # Para inferencia de modelos GGUF en CPU


### PR DESCRIPTION
## Summary
- call optional scheduler health endpoint before handing off
- call optional complaints health endpoint before handing off
- add httpx dependency

## Testing
- `pytest` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68c1deff9dd0832fb23907eea8f41e2d