### PR TITLE
Log handover emissions in agent and legacy scheduler flows

### DIFF
--- a/services/llm_docs-mcp/gateway.py
+++ b/services/llm_docs-mcp/gateway.py
@@ -923,6 +923,7 @@ async def agent_mode(req: dict):
 
             if isinstance(result, dict) and result.get("type") == "handover":
                 dt = int((time.time() - start_time) * 1000)
+                _logger.info("handover.emitted flow=%s source=agent", result.get("flow"))
                 _logger.info(
                     "agent.handover flow=%s duration_ms=%s",
                     result.get("flow"),
@@ -1035,6 +1036,7 @@ async def tools_call(request: Request):
             )
             return {"intent": flat, "sub_intent": sub_intent}
         elif tool == "scheduler-init":
+            _logger.info("handover.emitted flow=scheduler source=legacy")
             return {"type": "handover", "flow": "scheduler"}
         elif tool == "complaint-init":
             return {"type": "handover", "flow": "complaint"}


### PR DESCRIPTION
## Summary
- log agent handovers when emitting to other flows
- log legacy scheduler handover emissions

## Testing
- `pytest services/llm_docs-mcp/test_tools.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e6171ed0832fa39a21cbb88c4af4