### PR TITLE
feat: add configurable timeouts and retries

### DIFF
--- a/mcp-core/clients/llm_docs.py
+++ b/mcp-core/clients/llm_docs.py
@@ -2,6 +2,7 @@
 import os
 import logging
 import httpx
+import time
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -36,19 +37,42 @@ class LlmDocsClient:
             return (USER, PASSWORD)
         return None
 
-    def tools_call(self, tool: str, params: dict, trace_id: Optional[str] = None) -> dict:
+    def tools_call(
+        self,
+        tool: str,
+        params: dict,
+        trace_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+        retries: int = 0,
+    ) -> dict:
+        """Call the tools endpoint with optional timeout and retries."""
         payload = {"tool": tool, "params": params}
         if trace_id:
             payload["trace_id"] = trace_id
-        r = httpx.post(
-            self.base_url,
-            json=payload,
-            headers=self._headers(),
-            auth=self._auth(),
-            timeout=self.timeout,
-        )
-        r.raise_for_status()
-        return r.json()
+        to = timeout or self.timeout
+        for attempt in range(retries + 1):
+            try:
+                r = httpx.post(
+                    self.base_url,
+                    json=payload,
+                    headers=self._headers(),
+                    auth=self._auth(),
+                    timeout=to,
+                )
+                r.raise_for_status()
+                return r.json()
+            except (httpx.TimeoutException, httpx.RequestError) as e:
+                if attempt < retries:
+                    time.sleep(0.2 * (2**attempt))
+                    continue
+                logger.warning("tools_call error %s", e)
+                return {"error": str(e)}
+            except httpx.HTTPStatusError as e:
+                if attempt < retries and e.response.status_code >= 500:
+                    time.sleep(0.2 * (2**attempt))
+                    continue
+                logger.warning("tools_call http error %s", e)
+                return {"error": f"http_error_{e.response.status_code}"}
 
     def agent_call(self, messages, tools=None, categoria=None, timeout=None):
         payload = {"messages": messages}
@@ -64,15 +88,22 @@ class LlmDocsClient:
             payload["hints"] = {"categoria": categoria}
         logger.info("agent_call tools=%s categoria=%s", tools_log, categoria)
         to = timeout or self.timeout
-        r = httpx.post(
-            self.base_url,
-            json=payload,
-            headers=self._headers(),
-            auth=self._auth(),
-            timeout=to,
-        )
-        r.raise_for_status()
-        return r.json()
+        try:
+            r = httpx.post(
+                self.base_url,
+                json=payload,
+                headers=self._headers(),
+                auth=self._auth(),
+                timeout=to,
+            )
+            r.raise_for_status()
+            return r.json()
+        except (httpx.TimeoutException, httpx.RequestError) as e:
+            logger.warning("agent_call error %s", e)
+            return {"error": str(e)}
+        except httpx.HTTPStatusError as e:
+            logger.warning("agent_call http error %s", e)
+            return {"error": f"http_error_{e.response.status_code}"}
 
     # --- Alto nivel ---
     def classify_intent(self, texto: str, trace_id: Optional[str] = None) -> dict:

--- a/mcp-core/document_router.py
+++ b/mcp-core/document_router.py
@@ -7,6 +7,7 @@ import logging
 from typing import List, Optional, Tuple
 
 import requests
+import time
 from requests.auth import HTTPBasicAuth
 
 
@@ -22,8 +23,10 @@ LLM_DOCS_MCP_PASSWORD = os.getenv("LLM_DOCS_MCP_PASSWORD")
 class SemanticDocumentRouter:
     """Realiza el enrutamiento llamando al microservicio llm_docs-mcp."""
 
-    def __init__(self) -> None:
+    def __init__(self, timeout: float = 10.0, retries: int = 0) -> None:
         self.url = f"{LLM_DOCS_BASE}/semantic-route"
+        self.timeout = timeout
+        self.retries = retries
 
     def route(
         self, query: str, documents: List[dict], threshold: float = 0.5
@@ -34,20 +37,42 @@ class SemanticDocumentRouter:
             headers["X-API-KEY"] = LLM_DOCS_API_KEY
         if LLM_DOCS_MCP_USER and LLM_DOCS_MCP_PASSWORD:
             auth = HTTPBasicAuth(LLM_DOCS_MCP_USER, LLM_DOCS_MCP_PASSWORD)
-        try:
-            resp = requests.post(
-                self.url,
-                json={"query": query, "documents": documents, "threshold": threshold},
-                headers=headers,
-                auth=auth,
-                timeout=10,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return data.get("name"), float(data.get("score", 0.0))
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"Remote routing failed: {e}")
-            return None, 0.0
+        payload = {"query": query, "documents": documents, "threshold": threshold}
+        for attempt in range(self.retries + 1):
+            try:
+                resp = requests.post(
+                    self.url,
+                    json=payload,
+                    headers=headers,
+                    auth=auth,
+                    timeout=self.timeout,
+                )
+                if resp.status_code >= 500:
+                    raise requests.HTTPError(response=resp)
+                resp.raise_for_status()
+                data = resp.json()
+                return data.get("name"), float(data.get("score", 0.0))
+            except (requests.Timeout, requests.ConnectionError) as e:
+                logger.warning(
+                    "Remote routing transient error attempt=%s: %s", attempt, e
+                )
+                if attempt < self.retries:
+                    time.sleep(0.2 * (2**attempt))
+                    continue
+                return None, 0.0
+            except requests.HTTPError as e:
+                logger.warning("Remote routing http error %s", e)
+                if (
+                    e.response is not None
+                    and e.response.status_code >= 500
+                    and attempt < self.retries
+                ):
+                    time.sleep(0.2 * (2**attempt))
+                    continue
+                return None, 0.0
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"Remote routing failed: {e}")
+                return None, 0.0
 
 
 __all__ = ["SemanticDocumentRouter"]

--- a/mcp-core/orchestrator.py
+++ b/mcp-core/orchestrator.py
@@ -797,7 +797,11 @@ def _cb_success() -> None:
 
 
 def call_tool_microservice(
-    tool: str, params: Dict[str, Any], trace_id: str | None = None
+    tool: str,
+    params: Dict[str, Any],
+    trace_id: str | None = None,
+    timeout: float | None = None,
+    retries: int | None = None,
 ) -> Dict[str, Any]:
     service_url = route_to_service(tool)
     if tool.startswith("doc-"):
@@ -817,9 +821,13 @@ def call_tool_microservice(
         auth = HTTPBasicAuth(LLM_DOCS_MCP_USER, LLM_DOCS_MCP_PASSWORD)
     if tool.startswith("doc-") and LLM_DOCS_API_KEY:
         headers = {"X-API-KEY": LLM_DOCS_API_KEY}
-    timeout = LLM_DOCS_TIMEOUT if tool.startswith("doc-") else 30
-    retries = LLM_DOCS_RETRIES if tool.startswith("doc-") else 0
-    for attempt in range(retries + 1):
+    to = timeout if timeout is not None else (
+        LLM_DOCS_TIMEOUT if tool.startswith("doc-") else 30
+    )
+    rt = retries if retries is not None else (
+        LLM_DOCS_RETRIES if tool.startswith("doc-") else 0
+    )
+    for attempt in range(rt + 1):
         t0 = time.time()
         try:
             resp = requests.post(
@@ -827,7 +835,7 @@ def call_tool_microservice(
                 json=payload,
                 auth=auth,
                 headers=headers,
-                timeout=timeout,
+                timeout=to,
             )
             if resp.status_code >= 500:
                 raise requests.HTTPError(response=resp)
@@ -845,7 +853,7 @@ def call_tool_microservice(
                 f"llm_docs-mcp transient error attempt={attempt} tool={tool}: {e}",
                 extra={"trace_id": trace_id},
             )
-            if attempt < retries:
+            if attempt < rt:
                 time.sleep(0.2 * (2**attempt))
                 continue
             if tool.startswith("doc-"):
@@ -864,7 +872,7 @@ def call_tool_microservice(
                 f"HTTP error calling {service_url}: {status} - body={body}",
                 extra={"trace_id": trace_id},
             )
-            if status >= 500 and attempt < retries:
+            if status >= 500 and attempt < rt:
                 time.sleep(0.2 * (2**attempt))
                 continue
             if tool.startswith("doc-"):
@@ -881,7 +889,9 @@ def call_tool_microservice(
 
 def remote_llm_generate(prompt: str, timeout: float = 120.0) -> str:
     """Generate text using llm_docs-mcp via tools.call."""
-    resp = call_tool_microservice("doc-generar_respuesta_llm", {"pregunta": prompt})
+    resp = call_tool_microservice(
+        "doc-generar_respuesta_llm", {"pregunta": prompt}, timeout=timeout
+    )
     if resp.get("error"):
         raise Exception(resp["error"])
     return resp.get("respuesta", "")

--- a/services/scheduler-mcp/tasks.py
+++ b/services/scheduler-mcp/tasks.py
@@ -9,6 +9,7 @@ from notifications import send_email
 
 META_PHONE_ID = os.getenv('META_PHONE_ID')
 META_TOKEN = os.getenv('META_TOKEN')
+META_TIMEOUT = int(os.getenv('META_TIMEOUT', '10'))
 
 
 def fetch_tomorrow_confirmed(conn) -> Iterable[dict]:
@@ -41,7 +42,7 @@ def send_whatsapp(cita):
             "Authorization": f"Bearer {META_TOKEN}",
             "Content-Type": "application/json",
         }
-        requests.post(url, json=payload, headers=headers)
+        requests.post(url, json=payload, headers=headers, timeout=META_TIMEOUT)
     except Exception as e:
         print(f"Error al enviar WhatsApp a {cita['usuario_whatsapp']}: {e}")
 


### PR DESCRIPTION
## Summary
- make LlmDocsClient calls resilient with configurable timeouts, retries and error handling
- expose timeout/retry controls in `call_tool_microservice` and propagate to helpers
- harden document routing and WhatsApp notifications with timeout options and transient failure handling

## Testing
- `pytest mcp-core -q`
- `pytest -q` *(fails: assertion and connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c36b37f474832f8760db448d2bd1c2