### PR TITLE
chore: bump prometheus-client dependency

### DIFF
--- a/mcp-core/requirements.txt
+++ b/mcp-core/requirements.txt
@@ -9,7 +9,7 @@ rapidfuzz
 fakeredis
 chilean-rut
 phonenumbers
-prometheus_client>=0.16.0
+prometheus-client>=0.20.0
 python-json-logger
 scikit-learn>=0.24.2
 httpx

--- a/services/llm_docs-mcp/requirements.txt
+++ b/services/llm_docs-mcp/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.68.0
 uvicorn[standard]>=0.15.0
 scikit-learn>=0.24.2
-prometheus_client>=0.16.0
+prometheus-client>=0.20.0
 python-json-logger
 requests>=2.25.1
 httpx>=0.27.0


### PR DESCRIPTION
## Summary
- bump prometheus-client to >=0.20.0

## Testing
- `pytest` *(fails: 10 failed, 93 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ac79ea34832f8e71a65fbc19147e