### PR TITLE
Add telemetry analysis examples

### DIFF
--- a/docs/telemetria.md
+++ b/docs/telemetria.md
@@ -1,0 +1,37 @@
+# Telemetría
+
+Este documento describe cómo analizar logs JSON del agente para obtener métricas.
+
+## Cálculo de tasa `n/a` y distribución de handovers
+
+Suponiendo un archivo `logs.json` con eventos en formato JSON line, se pueden extraer
+las métricas directamente en la línea de comandos:
+
+```bash
+# Tasa de respuestas n/a
+jq -r 'select(.event=="trace.turn") | .answer' logs.json \
+  | awk '/^n\/a$/{na++} {total++} END {printf "%.2f\n", na/total}'
+
+# Distribución de handovers
+jq -r 'select(.event=="handover") | .department' logs.json \
+  | awk '{count[$1]++} END {for (d in count) printf "%s %d\n", d, count[d]}'
+```
+
+## Latencia p95 del agente
+
+Los eventos `trace.end` incluyen un campo `duration_ms` con el tiempo de respuesta. El
+percentil 95 se obtiene ordenando los valores y seleccionando el índice
+correspondiente:
+
+```bash
+jq -r 'select(.event=="trace.end") | .duration_ms' logs.json \
+  | sort -n \
+  | awk '{a[NR]=$1} END {idx=int(0.95*NR); print a[idx]}'
+```
+
+## Redacción de datos sensibles y hashing de `session_id`
+
+Los logs eliminan correos, teléfonos y RUT reemplazándolos por `<redacted>` antes de ser
+almacenados. Además, el identificador de sesión se hashifica con SHA-256 y una sal,
+truncándolo a 12 caracteres para evitar exponer la `session_id` original.
+


### PR DESCRIPTION
## Summary
- document jq+awk snippets for handover distribution and n/a rate
- show how to compute p95 latency from `duration_ms` logs
- note redaction of sensitive fields and hashing of `session_id`

## Testing
- `pytest` *(fails: redis connection errors and multiple test assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bc5bf674832f9941f73b534476ba