### PR TITLE
Add chat summary comparison script

### DIFF
--- a/tests/chat/README.md
+++ b/tests/chat/README.md
@@ -1,0 +1,16 @@
+# Chat Regression Tests
+
+Run the baseline and canary test suites:
+
+```bash
+python tests/chat/run_tests.py --testset tests/chat/testset.jsonl --results tests/chat/baseline_results.jsonl --summary tests/chat/summary_baseline.json
+python tests/chat/run_tests.py --testset tests/chat/testset.jsonl --results tests/chat/canary_results.jsonl --summary tests/chat/summary_canary.json
+```
+
+To compare the summaries and report the pass rate percentage and p95 latency for each environment, use the helper script:
+
+```bash
+./compare_summaries.sh
+```
+
+This script requires `jq` to be installed and assumes the summaries and result files live in `tests/chat/`.

--- a/tests/chat/compare_summaries.sh
+++ b/tests/chat/compare_summaries.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SUM=tests/chat/summary_baseline.json
+CAN_SUM=tests/chat/summary_canary.json
+BASE_RES=tests/chat/baseline_results.jsonl
+CAN_RES=tests/chat/canary_results.jsonl
+
+jq -n \
+  --slurpfile bsum "$BASE_SUM" \
+  --slurpfile br "$BASE_RES" \
+  --slurpfile csum "$CAN_SUM" \
+  --slurpfile cr "$CAN_RES" \
+  '
+    def p95(arr):
+      (arr | sort | .[(length * 0.95 | floor)]);
+    def pass_rate_pct(summary):
+      if summary.pass_rate_pct then summary.pass_rate_pct
+      elif summary.pass_rate then summary.pass_rate * 100
+      else null end;
+    {
+      baseline: {
+        pass_rate_pct: pass_rate_pct($bsum[0]),
+        p95_ms: p95([ $br[].latency_ms ])
+      },
+      canary: {
+        pass_rate_pct: pass_rate_pct($csum[0]),
+        p95_ms: p95([ $cr[].latency_ms ])
+      }
+    }
+  '


### PR DESCRIPTION
## Summary
- add `compare_summaries.sh` to inspect baseline vs canary test metrics (pass rate and p95 latency)
- document chat regression test workflow in `tests/chat/README.md`

## Testing
- `python tests/chat/run_tests.py --testset tests/chat/testset.jsonl --results tests/chat/baseline_results.jsonl --summary tests/chat/summary_baseline.json`
- `python tests/chat/run_tests.py --testset tests/chat/testset.jsonl --results tests/chat/canary_results.jsonl --summary tests/chat/summary_canary.json`
- `tests/chat/compare_summaries.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c5a1f81a60832f9e316ba12466fc12