### PR TITLE
Agregar runbook para desactivar agentes

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,9 @@
+# RUNBOOK
+
+## Desactivar agentes
+
+1. Establecer `AGENT_MODE=0`, `AGENT_CANARY_RATIO=0`, `RAG_CATEGORY_AWARE=0`.
+2. Reconstruir/recargar servicios.
+3. Ejecutar subset del test set para confirmar que las salidas coinciden con `baseline_results.jsonl`.
+4. Verificar ausencia de eventos `agent.*` en logs y métricas Prometheus.
+


### PR DESCRIPTION
## Summary
- documenta pasos para desactivar agentes y validar que no generen eventos

## Testing
- `pip install -r mcp-core/requirements.txt`
- `pytest` *(falla: redis no disponible, 11 fallos)*


------
https://chatgpt.com/codex/tasks/task_e_68c5a61556a0832faa8ebd81820aeff1