### PR TITLE
Remove unused LLM/RAG services from deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,10 @@
-# Modo de funcionamiento del agente (0 = predeterminado)
-AGENT_MODE=0
-
-# Habilita recuperación sensible a la categoría (0 = deshabilitado)
-RAG_CATEGORY_AWARE=0
-
-# Número máximo de llamadas a herramientas permitidas al agente
-AGENT_MAX_TOOL_CALLS=2
-
-# Modo de selección de RAG por categoría: collection | filter
-RAG_SELECTION_MODE=collection
-# Campo de metadato a usar cuando RAG_SELECTION_MODE=filter
-RAG_FILTER_FIELD=tipo
-
-# Colección RAG para preguntas frecuentes
-RAG_COLLECTION_FAQ=faq
-
-# Colección RAG para trámites
-RAG_COLLECTION_TRAMITES=tramites
-
-# Colección RAG para normativa
-RAG_COLLECTION_NORMATIVA=normativa
+# === Grafana credentials (monitoring) ===
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
 
 # === Rescate por similitud de intents ===
 INTENT_SIMILARITY_PATH=mcp-core/config/intent_similarities.json
 INTENT_SIMILARITY_THRESHOLD=0.55
-
-# === Grafana credentials (monitoring) ===
-GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=admin
 
 # URLs de microservicios para el orquestador
 SCHEDULER_MCP_URL=http://scheduler-mcp:6001/tools/call

--- a/.env.sample
+++ b/.env.sample
@@ -6,44 +6,8 @@
 # =====================================
 # Example:
 # DATABASE_URL=postgresql://user:password@host:port/database
-# QDRANT_URL=http://qdrant:6333
 # SCHEDULER_HEALTH_URL=http://scheduler-mcp:6001/health
 # COMPLAINTS_HEALTH_URL=http://complaints-mcp:7000/health
-
-# =====================================
-# Feature Flags & Agent Tuning
-# =====================================
-# AGENT_MODE: Activates agent mode in llm_docs-mcp/orchestrator (0=off, 1=on)
-AGENT_MODE=0
-
-# RAG_CATEGORY_AWARE: Enables RAG to select collection/filter by category (0=off, 1=on)
-RAG_CATEGORY_AWARE=0
-
-# AGENT_MAX_TOOL_CALLS: Limit of tool calls per agent turn
-AGENT_MAX_TOOL_CALLS=2
-
-# RAG_COLLECTION_*: Collection names (or aliases) for each category
-RAG_COLLECTION_FAQ=faq
-RAG_COLLECTION_TRAMITES=tramites
-RAG_COLLECTION_NORMATIVA=normativa
-
-# RAG_SELECTION_MODE: How to select RAG data by category ('collection' or 'filter').
-RAG_SELECTION_MODE=collection
-
-# RAG_FILTER_FIELD: If RAG_SELECTION_MODE=filter, specifies the metadata field to use (e.g., "tipo").
-RAG_FILTER_FIELD=tipo
-
-# =====================================
-# Agent Guardrails (llm_docs-mcp)
-# =====================================
-# Timeout in seconds for the LLM to generate a response within the agent loop.
-AGENT_LLM_TIMEOUT_SEC=8
-
-# Timeout in seconds for a tool handler to execute.
-AGENT_HANDLER_TIMEOUT_SEC=4
-
-# Number of retries for a timed-out operation (0 or 1 recommended).
-AGENT_MAX_RETRIES=1
 
 # =====================================
 # Telemetry & Observability

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,6 @@ services:
         condition: service_healthy
       complaints-mcp:
         condition: service_started
-      llm_docs-mcp:
-        condition: service_started
       scheduler-mcp:
         condition: service_started
 
@@ -93,22 +91,6 @@ services:
       timeout: 5s
       retries: 5
 
-  qdrant:
-    image: qdrant/qdrant:v1.7.0
-    container_name: qdrant
-    ports:
-      - "6333:6333"
-    networks:
-      - munbot-net
-    volumes:
-      - qdrant_data:/qdrant/storage
-    healthcheck:
-      test: ["CMD-SHELL", "exit 0"]
-      interval: 5s
-      timeout: 2s
-      retries: 1
-      start_period: 1s
-      
   mcp-core:
     build:
       context: .
@@ -123,10 +105,6 @@ services:
       - HUMAN_ESCALATION_LOG=/app/human_escalations.log
       - PROMPTS_PATH=/app/mcp-core/prompts
       - TOOL_SCHEMAS_PATH=/app/mcp-core/tool_schemas
-      - LLM_DOCS_MCP_URL=http://llm_docs-mcp:8000/tools/call
-      - LLM_DOCS_API_KEY=${LLM_DOCS_API_KEY:-}
-      - LLM_DOCS_MCP_USER=${LLM_DOCS_MCP_USER:-}
-      - LLM_DOCS_MCP_PASSWORD=${LLM_DOCS_MCP_PASSWORD:-}
       - SCHEDULER_MCP_URL=${SCHEDULER_MCP_URL:-http://scheduler-mcp:6001/tools/call}
       - COMPLAINTS_MCP_URL=${COMPLAINTS_MCP_URL:-http://complaints-mcp:7000/tools/call}
       - INTENT_SIMILARITY_PATH=${INTENT_SIMILARITY_PATH:-mcp-core/config/intent_similarities.json}
@@ -138,14 +116,11 @@ services:
     volumes:
       - ./mcp-core/models:/mcp-core/models
       - ./services:/app/services:ro
-      - ./services/llm_docs-mcp/documents:/app/documents:ro
       - ./logs/human_escalations.log:/app/human_escalations.log
     depends_on:
       redis:
         condition: service_healthy
       postgres:
-        condition: service_healthy
-      llm_docs-mcp:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
@@ -183,58 +158,6 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-
-  llm_docs-mcp:
-    build:
-      context: .
-      dockerfile: services/llm_docs-mcp/Dockerfile
-    container_name: llm_docs-mcp
-    env_file:
-      - ./.env
-    environment:
-      - AUTO_INDEX=1
-      - COLLECTION=munbot_docs
-      - QDRANT_COLLECTION=munbot_docs
-      - QDRANT_HOST=qdrant
-      - QDRANT_PORT=6333
-      - EMBEDDINGS_DIM=384
-      - EMBEDDINGS_MODEL=sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2
-      - DOCS_DIR=/app/documents
-      - REDIS_HOST=redis
-      - QDRANT_SIMILARITY_THRESHOLD=0.3
-      - LLM_MAX_NEW_TOKENS=200
-      # Path used by llama_cpp in llama_runner.py
-      - LLAMA_MODEL_PATH=/app/models/Qwen2.5-3B-Instruct-Q4_K_L.gguf
-      # Optional: legacy variable retained for clarity; not used by llama_runner
-      - MODEL_PATH=/app/models/Qwen2.5-3B-Instruct-Q4_K_L.gguf # o nombre HF para transformers
-      - N_THREADS=4
-      - N_CTX=2048
-      - ALLOWED_IPS=127.0.0.1,172.18.0.0/16
-      - LLM_DOCS_API_KEY=${LLM_DOCS_API_KEY:-}
-      - LLM_DOCS_MCP_USER=${LLM_DOCS_MCP_USER:-}
-      - LLM_DOCS_MCP_PASSWORD=${LLM_DOCS_MCP_PASSWORD:-}
-      - LOG_DIR=/app/logs
-      - LOG_PATH=/app/logs/llm_docs_gateway.log
-      - INTENT_OUTPUT_MODE=rich
-    depends_on:
-      qdrant:
-        condition: service_started
-    expose:
-      - "8000"
-    restart: unless-stopped
-    networks:
-      - munbot-net
-    healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request,sys;             sys.exit(urllib.request.urlopen('http://localhost:8000/health').getcode()!=200)"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      # Período de gracia para que el contenedor complete su arranque (indexación, carga de modelos)
-      start_period: 300s
-    volumes:
-      
-      - ./services/llm_docs-mcp/documents:/app/documents:ro
-      - ./logs:/app/logs
 
   scheduler-mcp:
     build: 
@@ -303,6 +226,5 @@ networks:
 
 volumes:
   postgres_data:
-  qdrant_data:
   prometheus_data:
   grafana_data:

--- a/mcp-core/wait-for-deps.sh
+++ b/mcp-core/wait-for-deps.sh
@@ -6,26 +6,11 @@ REDIS_HOST=${REDIS_HOST:-redis}
 REDIS_PORT=${REDIS_PORT:-6379}
 POSTGRES_HOST=${POSTGRES_HOST:-postgres}
 POSTGRES_PORT=${POSTGRES_PORT:-5432}
-QDRANT_HOST=${QDRANT_HOST:-qdrant}
-QDRANT_PORT=${QDRANT_PORT:-6333}
-LLM_DOCS_HOST=${LLM_DOCS_MCP_HOST:-llm_docs-mcp}
-LLM_DOCS_PORT=${LLM_DOCS_MCP_PORT:-8000}
-LLM_DOCS_HEALTH_URL=${LLM_DOCS_MCP_HEALTH_URL:-http://$LLM_DOCS_HOST:$LLM_DOCS_PORT/health}
-
 echo "→ Esperando a Redis en $REDIS_HOST:$REDIS_PORT..."
 until nc -z "$REDIS_HOST" "$REDIS_PORT"; do sleep 2; done
 
 echo "→ Esperando a Postgres en $POSTGRES_HOST:$POSTGRES_PORT..."
 until nc -z "$POSTGRES_HOST" "$POSTGRES_PORT"; do sleep 2; done
-
-echo "→ Esperando a Qdrant en $QDRANT_HOST:$QDRANT_PORT..."
-until nc -z "$QDRANT_HOST" "$QDRANT_PORT"; do sleep 2; done
-
-echo "→ Esperando a llm_docs-mcp (puerto TCP) en $LLM_DOCS_HOST:$LLM_DOCS_PORT..."
-until nc -z "$LLM_DOCS_HOST" "$LLM_DOCS_PORT"; do sleep 2; done
-
-echo "→ Esperando al endpoint de salud de llm_docs-mcp en $LLM_DOCS_HEALTH_URL..."
-until curl -sf "$LLM_DOCS_HEALTH_URL" >/dev/null 2>&1; do sleep 2; done
 
 echo "→ Todas las dependencias listas. Iniciando mcp‑core..."
 exec "$@"


### PR DESCRIPTION
## Summary
- remove the llm_docs-mcp and qdrant services from docker-compose and clean up dependent configuration
- simplify the environment templates to drop LLM/RAG-specific variables
- update the mcp-core startup script to only wait for redis and postgres

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ffd13711e4832f9a62dd27b1f60d07